### PR TITLE
Create reusable back button component

### DIFF
--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+
+interface BackButtonProps {
+  to?: string;
+  className?: string;
+}
+
+const BackButton: React.FC<BackButtonProps> = ({ to = '/', className = "mb-3" }) => {
+  const navigate = useNavigate();
+
+  return (
+    <Button 
+      variant="outline-secondary" 
+      onClick={() => navigate(to)} 
+      className={className}
+      aria-label="Volver al Dashboard"
+    >
+      <svg 
+        width="16" 
+        height="16" 
+        fill="currentColor" 
+        viewBox="0 0 16 16"
+        style={{ marginRight: '8px' }}
+      >
+        <path fillRule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"/>
+      </svg>
+      Volver al Dashboard
+    </Button>
+  );
+};
+
+export default BackButton;

--- a/frontend/src/components/Candidates.tsx
+++ b/frontend/src/components/Candidates.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Card, Container, Row, Col, Form, Button, Alert, Spinner } from 'react-bootstrap';
 import { getCandidates } from '../services/candidateService';
 import { Candidate } from '../models/types/Candidate';
+import BackButton from './BackButton';
 
 const Candidates: React.FC = () => {
     const [candidates, setCandidates] = useState<Candidate[]>([]);
@@ -66,9 +67,7 @@ const Candidates: React.FC = () => {
 
     return (
         <Container className="mt-5">
-            <Button variant="link" onClick={() => navigate('/')} className="mb-3">
-                Volver al Dashboard
-            </Button>
+            <BackButton />
             <h2 className="text-center mb-4">Candidatos</h2>
             
             <Row className="mb-4">

--- a/frontend/src/components/Positions.tsx
+++ b/frontend/src/components/Positions.tsx
@@ -4,6 +4,7 @@ import { Card, Container, Row, Col, Form, Button } from 'react-bootstrap';
 import axios from 'axios';
 import { Position } from '../models/types/Position';
 import { getPositionStatusBadgeColor } from '../models/enums/PositionStatus';
+import BackButton from './BackButton';
 
 const Positions: React.FC = () => {
     const [positions, setPositions] = useState<Position[]>([]);
@@ -45,9 +46,7 @@ const Positions: React.FC = () => {
 
     return (
         <Container className="mt-5">
-            <Button variant="link" onClick={() => navigate('/')} className="mb-3">
-                Volver al Dashboard
-            </Button>
+            <BackButton />
             <h2 className="text-center mb-4">Posiciones</h2>
             <Row className="mb-4">
                 <Col md={3}>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Create a reusable `BackButton` component to standardize, visually enhance, and centralize the 'Back to Dashboard' functionality in Candidates and Positions views.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The original buttons were simple links, making them less discoverable as interactive elements. This change ensures they appear as clear buttons with an intuitive back arrow icon, improving user experience and consistency.