### PR TITLE
feat(SCRUM-85): Group recruiter dashboard and archive OpenSpec change

### DIFF
--- a/frontend/src/components/RecruiterDashboard.js
+++ b/frontend/src/components/RecruiterDashboard.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Card, Container, Row, Col } from 'react-bootstrap';
+import { Button, Card, Col, Container, Row } from 'react-bootstrap';
+import { Briefcase, PersonBadge } from 'react-bootstrap-icons';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import logo from '../assets/lti-logo.png';
@@ -13,22 +14,54 @@ const RecruiterDashboard = () => {
                 <img src={logo} alt={t('dashboard.logoAlt')} style={{ width: '150px' }} />
             </div>
             <h1 className="mb-4 text-center">{t('dashboard.title')}</h1>
-            <Row>
-                <Col md={6}>
-                    <Card className="shadow p-4">
-                        <h5 className="mb-4">{t('dashboard.candidates.title')}</h5>
-                        <Link to="/add-candidate">
-                            <Button variant="primary" className="btn-block">{t('dashboard.candidates.button')}</Button>
-                        </Link>
-                    </Card>
+            <Row className="g-4 gx-md-5 justify-content-center">
+                <Col xs={12} md={6} lg={5}>
+                    <section aria-labelledby="dashboard-section-candidates-heading">
+                        <h2
+                            id="dashboard-section-candidates-heading"
+                            className="h4 fw-semibold d-flex align-items-center gap-2 mb-2"
+                        >
+                            <PersonBadge className="text-primary flex-shrink-0" aria-hidden size={26} />
+                            {t('dashboard.sections.candidates.heading')}
+                        </h2>
+                        <p className="text-muted small mb-3">{t('dashboard.sections.candidates.lead')}</p>
+                        <Card className="shadow-sm border-0 h-100">
+                            <Card.Body className="p-4">
+                                <p className="fw-semibold text-secondary mb-3 mb-md-4">
+                                    {t('dashboard.candidates.title')}
+                                </p>
+                                <Link to="/add-candidate" className="text-decoration-none">
+                                    <Button variant="primary" className="w-100">
+                                        {t('dashboard.candidates.button')}
+                                    </Button>
+                                </Link>
+                            </Card.Body>
+                        </Card>
+                    </section>
                 </Col>
-                <Col md={6}>
-                    <Card className="shadow p-4">
-                        <h5 className="mb-4">{t('dashboard.positions.title')}</h5>
-                        <Link to="/positions">
-                            <Button variant="primary" className="btn-block">{t('dashboard.positions.button')}</Button>
-                        </Link>
-                    </Card>
+                <Col xs={12} md={6} lg={5}>
+                    <section aria-labelledby="dashboard-section-positions-heading">
+                        <h2
+                            id="dashboard-section-positions-heading"
+                            className="h4 fw-semibold d-flex align-items-center gap-2 mb-2"
+                        >
+                            <Briefcase className="text-primary flex-shrink-0" aria-hidden size={26} />
+                            {t('dashboard.sections.positions.heading')}
+                        </h2>
+                        <p className="text-muted small mb-3">{t('dashboard.sections.positions.lead')}</p>
+                        <Card className="shadow-sm border-0 h-100">
+                            <Card.Body className="p-4">
+                                <p className="fw-semibold text-secondary mb-3 mb-md-4">
+                                    {t('dashboard.positions.title')}
+                                </p>
+                                <Link to="/positions" className="text-decoration-none">
+                                    <Button variant="primary" className="w-100">
+                                        {t('dashboard.positions.button')}
+                                    </Button>
+                                </Link>
+                            </Card.Body>
+                        </Card>
+                    </section>
                 </Col>
             </Row>
         </Container>

--- a/frontend/src/i18n/__tests__/i18nIntegration.test.tsx
+++ b/frontend/src/i18n/__tests__/i18nIntegration.test.tsx
@@ -35,6 +35,13 @@ describe('RecruiterDashboard i18n', () => {
       </MemoryRouter>
     );
     expect(screen.getByText('Recruiter Dashboard')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Candidates' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Positions' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Create applicant profiles and manage candidate records.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Add New Candidate' })).toHaveAttribute('href', '/add-candidate');
+    expect(screen.getByRole('link', { name: 'Go to Positions' })).toHaveAttribute('href', '/positions');
   });
 
   it('renders Spanish heading with locale es', () => {
@@ -47,5 +54,13 @@ describe('RecruiterDashboard i18n', () => {
       </MemoryRouter>
     );
     expect(screen.getByText('Dashboard del Reclutador')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Candidatos' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Posiciones' })).toBeInTheDocument();
+    expect(screen.getByText('Crea fichas de candidatos y gestiona sus datos.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Añadir Nuevo Candidato' })).toHaveAttribute(
+      'href',
+      '/add-candidate'
+    );
+    expect(screen.getByRole('link', { name: 'Ir a Posiciones' })).toHaveAttribute('href', '/positions');
   });
 });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -12,6 +12,16 @@
   "dashboard": {
     "title": "Recruiter Dashboard",
     "logoAlt": "LTI Logo",
+    "sections": {
+      "candidates": {
+        "heading": "Candidates",
+        "lead": "Create applicant profiles and manage candidate records."
+      },
+      "positions": {
+        "heading": "Positions",
+        "lead": "Open roles, pipelines, and position details."
+      }
+    },
     "candidates": {
       "title": "Add Candidate",
       "button": "Add New Candidate"

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -12,6 +12,16 @@
   "dashboard": {
     "title": "Dashboard del Reclutador",
     "logoAlt": "Logo LTI",
+    "sections": {
+      "candidates": {
+        "heading": "Candidatos",
+        "lead": "Crea fichas de candidatos y gestiona sus datos."
+      },
+      "positions": {
+        "heading": "Posiciones",
+        "lead": "Roles abiertos, procesos y detalles de cada posición."
+      }
+    },
     "candidates": {
       "title": "Añadir Candidato",
       "button": "Añadir Nuevo Candidato"

--- a/openspec/changes/archive/2026-05-09-scrum-85/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-09-scrum-85/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/archive/2026-05-09-scrum-85/design.md
+++ b/openspec/changes/archive/2026-05-09-scrum-85/design.md
@@ -1,0 +1,58 @@
+# Design — SCRUM-85: Recruiter dashboard grouping and restyle
+
+## Context
+
+`RecruiterDashboard.js` renders the app root (`/`): centered logo, `h1`, and two `Col md={6}` cards with links to `/add-candidate` and `/positions`. Internationalization uses `useTranslation` and keys under `dashboard.*`. The stack is React 18, React Router 6, React Bootstrap, Bootstrap 5, and i18next per `docs/frontend-standards.md`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make **Candidates** and **Positions** workflows visually distinct via section structure (headings, spacing, optional short description under each section).
+- Improve visual hierarchy (card styling, typography scale, optional icons) while staying on Bootstrap / React Bootstrap.
+- Keep routes and link targets unchanged; no new network calls.
+- Meet basic accessibility: logical heading order, descriptive link text, sufficient contrast.
+
+**Non-Goals:**
+
+- Dashboard metrics, charts, or new APIs.
+- Candidate listing or search from the home page.
+- Auth or role-based visibility.
+- Replacing Bootstrap with another CSS framework.
+
+## Decisions
+
+1. **Section structure**  
+   Use a **page-level `h1`** (existing title), then **two regions** each introduced by an **`h2`** (or `h2` + optional `p` lead) wrapping the action card(s) for that workflow. This satisfies grouping and keeps a sensible heading outline.
+
+   *Alternative considered:* Tabs for Candidates vs Positions — rejected because it hides one workflow and adds interaction cost for a simple two-action screen.
+
+2. **Layout**  
+   Prefer `Container` → `Stack` or `Row`/`Col` with **vertical stacking on `xs`**, **two-column layout from `md` upward** so each section group reads as a column of content. Maintain full-width readable tap targets on mobile.
+
+   *Alternative considered:* Always single column — acceptable if design uses strong section dividers; two-column from `md` matches current behavior and scales well.
+
+3. **Icons**  
+   Optional **`react-bootstrap-icons`** (already a project dependency per frontend standards) for section headers (e.g. person icon vs briefcase). Icons are decorative or paired with visible text (`aria-hidden` where redundant).
+
+4. **Styling**  
+   Prefer **Bootstrap utility classes** and React Bootstrap props (`className`, `Card`, etc.). Touch `index.css` only for one-off spacing if utilities are insufficient.
+
+5. **i18n**  
+   Add nested keys under `dashboard`, e.g. `dashboard.sections.candidates.title`, `dashboard.sections.candidates.description`, mirror in `es.json`. Do not leave empty or TODO strings.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Heading order regressions confuse screen readers | Code review checklist: single `h1`, then section `h2`s; validate in browser a11y tree |
+| String drift between `en` and `es` | Run or extend parity tests; mirror keys when adding strings |
+| Over-styled cards hurt consistency | Reuse patterns from `Positions.tsx` / other list pages where possible |
+
+## Migration Plan
+
+Not applicable: static UI change, deploy with normal frontend release. Rollback = revert component and locale commits.
+
+## Open Questions
+
+- None for MVP; product may later request dashboard widgets or additional quick actions.

--- a/openspec/changes/archive/2026-05-09-scrum-85/proposal.md
+++ b/openspec/changes/archive/2026-05-09-scrum-85/proposal.md
@@ -1,0 +1,33 @@
+# Proposal — SCRUM-85: Recruiter dashboard layout and grouping
+
+## Why
+
+The recruiter home page (`/`) shows two similar cards without a clear information hierarchy, so candidate and position workflows are easy to confuse. We need an explicit visual grouping and refreshed layout so recruiters orient faster, without changing underlying routes or backend behavior.
+
+## What Changes
+
+- Restructure `RecruiterDashboard` into two clearly labeled **sections** (Candidates vs Positions) with improved typography, spacing, and optional icons (React Bootstrap / `react-bootstrap-icons`).
+- Preserve existing navigation: primary action to **add a candidate** → `/add-candidate`; primary action to **open positions** → `/positions`.
+- Extend `dashboard.*` i18n keys in `en.json` and `es.json` for any new section titles, subtitles, or accessibility labels; maintain key parity (existing `frontend-i18n` global rules still apply).
+- Improve responsive behavior (stacked layout on small screens, readable targets).
+- No backend or API contract changes; no new data fetching on the dashboard.
+
+## Capabilities
+
+### New Capabilities
+
+- `recruiter-dashboard-layout`: Defines the recruiter home page structure, visual grouping of candidate vs position actions, navigation preservation, responsive layout, and accessibility expectations for the dashboard.
+
+### Modified Capabilities
+
+- None. Locale parity and `useTranslation` usage remain governed by the existing `frontend-i18n` capability in `openspec/specs/frontend-i18n/spec.md`; this change only adds keys under the existing `dashboard` namespace.
+
+## Impact
+
+| Area | Impact |
+|------|--------|
+| Frontend | `frontend/src/components/RecruiterDashboard.js`; optional `frontend/src/index.css` |
+| i18n | `frontend/src/i18n/locales/en.json`, `es.json` |
+| Tests | `frontend/src/i18n/__tests__/i18nIntegration.test.tsx`; optional new RTL tests; optional Cypress e2e |
+| Backend | None |
+| API / data model docs | None |

--- a/openspec/changes/archive/2026-05-09-scrum-85/reports/2026-05-09-step-4-frontend-unit-test-verification.md
+++ b/openspec/changes/archive/2026-05-09-scrum-85/reports/2026-05-09-step-4-frontend-unit-test-verification.md
@@ -1,0 +1,31 @@
+# Step 4 — Frontend unit tests and verification
+
+- Date: 2026-05-09
+- Change: scrum-85 (SCRUM-85)
+- Agent: Cursor implementation pass
+
+## Commands executed
+
+- `CI=true npm exec react-scripts test -- --watchAll=false --testPathPattern=i18nIntegration` — RecruiterDashboard i18n tests
+- `CI=true npm exec react-scripts test -- --watchAll=false` — full frontend Jest suite
+- `npx eslint src/components/RecruiterDashboard.js src/i18n/__tests__/i18nIntegration.test.tsx`
+
+## Unit test results
+
+- Targeted (i18n integration): **2 passed**
+- Full suite (`react-scripts test`): **3 suites, 14 tests passed**
+
+**Note:** Root `frontend/package.json` script `jest --config jest.config.js` fails because `jest.config.js` is missing from this workspace; tests were run via `react-scripts test` successfully.
+
+## Database / backend
+
+- **N/A.** No backend or database mutations for SCRUM-85.
+
+## Step 5 — curl manual endpoint testing
+
+- **Out of scope:** No new or changed REST endpoints; curl regression not required for this UI-only change.
+
+## Outcome
+
+- Step 4: **PASS**
+- ESLint on touched files: **PASS** (exit code 0)

--- a/openspec/changes/archive/2026-05-09-scrum-85/reports/2026-05-09-step-6-e2e-playwright.md
+++ b/openspec/changes/archive/2026-05-09-scrum-85/reports/2026-05-09-step-6-e2e-playwright.md
@@ -1,0 +1,31 @@
+# Step 6 — E2E browser verification (SCRUM-85)
+
+- Date: 2026-05-09
+- Change: scrum-85
+- Environment: CRA dev server `http://localhost:3000` (`BROWSER=none PORT=3000 npm start`)
+
+## Tooling note
+
+The **Playwright MCP** server was not available in this session (`user-playwright` not registered). E2E was executed with the **user-concurrent-browser** MCP (Chromium, headless): `browser_create_instance` → `browser_navigate` → `browser_get_markdown` / `browser_click` → `browser_evaluate`.
+
+## Scenarios
+
+1. **Dashboard sections**
+   - Navigated to `http://localhost:3000/`.
+   - Markdown snapshot showed `# Recruiter Dashboard`, `## Candidates`, `## Positions`, lead copy, and action labels — grouped layout confirmed.
+
+2. **Candidate primary action**
+   - Clicked `a[href="/add-candidate"]`.
+   - Page URL became `http://localhost:3000/add-candidate`.
+
+3. **Positions primary action**
+   - Returned to `http://localhost:3000/`.
+   - Clicked `a[href="/positions"]`.
+   - `window.location.pathname` evaluated to `/positions`.
+
+4. **Responsive viewport (optional)**
+   - Default instance viewport 1280×720; full scenario not repeated at mobile width (optional per tasks).
+
+## Outcome
+
+- Step 6: **PASS** (browser automation via concurrent-browser MCP).

--- a/openspec/changes/archive/2026-05-09-scrum-85/specs/recruiter-dashboard-layout/spec.md
+++ b/openspec/changes/archive/2026-05-09-scrum-85/specs/recruiter-dashboard-layout/spec.md
@@ -1,0 +1,68 @@
+# recruiter-dashboard-layout (delta)
+
+## ADDED Requirements
+
+### Requirement: Recruiter home page groups candidate and position actions
+
+The system SHALL render the recruiter dashboard at route `/` with two distinct groups: one for **candidate-related** actions and one for **position-related** actions. Each group SHALL include a visible section title and at least one primary navigation control. The candidate group SHALL provide access to add a candidate (navigate to `/add-candidate`). The position group SHALL provide access to the positions list (navigate to `/positions`).
+
+#### Scenario: Candidate group links to add candidate
+
+- **WHEN** the user views `/`
+- **THEN** a candidate workflow section is visible and includes a control that navigates to `/add-candidate`
+
+#### Scenario: Position group links to positions list
+
+- **WHEN** the user views `/`
+- **THEN** a position workflow section is visible and includes a control that navigates to `/positions`
+
+#### Scenario: Sections are distinguishable from each other
+
+- **WHEN** the dashboard is rendered
+- **THEN** candidate and position groups are visually separated by section headings and/or spacing so a typical user can tell which actions belong to which workflow
+
+### Requirement: Dashboard layout and responsiveness
+
+The dashboard SHALL use React Bootstrap and Bootstrap patterns consistent with `docs/frontend-standards.md`. Content SHALL be usable on narrow viewports (stacked layout, adequate spacing and touch targets) and on `md` and wider viewports (clear multi-column or structured layout without horizontal overflow).
+
+#### Scenario: Narrow viewport stacks content
+
+- **WHEN** the viewport width is below the `md` breakpoint
+- **THEN** section groups stack vertically and remain readable without horizontal scrolling
+
+#### Scenario: Wider viewport shows structured layout
+
+- **WHEN** the viewport width is at or above the `md` breakpoint
+- **THEN** the page presents a clear structured layout (e.g. two columns or equivalent) that preserves both workflow groups
+
+### Requirement: Internationalization for new dashboard copy
+
+All new or changed user-visible strings on the recruiter dashboard SHALL be defined under the `dashboard` namespace in both `frontend/src/i18n/locales/en.json` and `frontend/src/i18n/locales/es.json` with identical key structure. The component SHALL resolve them through `useTranslation()` and `t()`.
+
+#### Scenario: English and Spanish keys exist for new strings
+
+- **WHEN** a new translation key is added for dashboard section titles or descriptions
+- **THEN** the same key path exists in both `en.json` and `es.json` with non-empty values
+
+### Requirement: Accessible structure for the recruiter dashboard
+
+The page SHALL expose a logical heading hierarchy: exactly one primary page title suitable for `h1`, and section titles for each workflow group using heading elements (e.g. `h2`). Links SHALL have descriptive visible text or accessible names so purpose is clear out of context.
+
+#### Scenario: Heading hierarchy is logical
+
+- **WHEN** assistive technology reads the `/` page
+- **THEN** a single primary document title precedes section headings for candidate and position groups in a logical order
+
+#### Scenario: Primary actions have clear names
+
+- **WHEN** the user inspects candidate and position primary links or buttons
+- **THEN** each target’s purpose is clear from its label (via `t()`-resolved text or equivalent)
+
+### Requirement: No new backend coupling on the dashboard
+
+The recruiter dashboard SHALL NOT introduce new HTTP requests or dependency on new backend endpoints solely for this change. Existing client-side routing and downstream pages remain responsible for API usage.
+
+#### Scenario: Dashboard renders without fetching dashboard-specific data
+
+- **WHEN** the user loads `/` with the application in a normal running state
+- **THEN** the dashboard does not require new API endpoints introduced by SCRUM-85 to render grouped sections and links

--- a/openspec/changes/archive/2026-05-09-scrum-85/tasks.md
+++ b/openspec/changes/archive/2026-05-09-scrum-85/tasks.md
@@ -1,0 +1,54 @@
+# Tasks — SCRUM-85: Recruiter dashboard grouping and restyle
+
+## 0. Setup: Create Feature Branch (MANDATORY — FIRST STEP)
+
+- [x] 0.1 Create and switch to branch `feature/scrum-85-frontend` from the target integration branch
+- [x] 0.2 Confirm current branch and clean working tree before implementation
+
+## 1. Internationalization (before or with UI)
+
+- [x] 1.1 Add structured `dashboard` keys in `frontend/src/i18n/locales/en.json` for section titles, optional descriptions, and any new control labels
+- [x] 1.2 Mirror the same key paths and non-empty values in `frontend/src/i18n/locales/es.json`
+- [x] 1.3 Ensure no hardcoded user-visible strings remain in `RecruiterDashboard.js` for the changed areas
+
+## 2. Frontend: Layout and grouping
+
+- [x] 2.1 Refactor `frontend/src/components/RecruiterDashboard.js` to render two distinct workflow sections (Candidates vs Positions) with section headings per `design.md`
+- [x] 2.2 Preserve navigation targets: `/add-candidate` for the add-candidate action and `/positions` for the positions entry
+- [x] 2.3 Apply responsive layout (stack on small screens; structured layout from `md`+) using React Bootstrap / Bootstrap utilities
+- [x] 2.4 Optionally add icons from `react-bootstrap-icons` with correct accessibility (decorative vs labeled)
+- [x] 2.5 Only add scoped styles to `frontend/src/index.css` if utilities are insufficient
+
+## 3. Frontend: Review and update existing unit tests (MANDATORY)
+
+- [x] 3.1 Update `frontend/src/i18n/__tests__/i18nIntegration.test.tsx` (and any assertions) to match new `dashboard.*` strings or headings
+- [x] 3.2 Add or extend RTL tests for `RecruiterDashboard` if new structure or roles warrant coverage
+
+## 4. Frontend: Run unit tests and record results (MANDATORY — AGENT MUST EXECUTE)
+
+- [x] 4.1 Run targeted frontend tests (e.g. `npm test` scoped to dashboard/i18n) from `frontend/` and capture output
+- [x] 4.2 Run the project’s configured frontend lint/unit suite as needed so regressions surface before merge
+- [x] 4.3 Create report `openspec/changes/scrum-85/reports/2026-05-09-step-4-frontend-unit-test-verification.md` with commands, pass/fail summary, and notes (database N/A — state explicitly)
+
+## 5. Backend: Manual endpoint testing with curl (N/A)
+
+- [x] 5.1 Record in the same step-4 report (or a one-line appendix) that **no new or changed REST endpoints** are part of SCRUM-85; **curl regression is out of scope** for this change
+
+## 6. E2E: Playwright MCP (MANDATORY — AGENT MUST EXECUTE — UI WORKFLOW)
+
+- [x] 6.1 Start frontend (and backend only if required for app health in this project’s dev setup)
+- [x] 6.2 Navigate to `/` and verify both workflow sections are visible and visually grouped
+- [x] 6.3 Follow candidate primary action to `/add-candidate` and confirm navigation
+- [x] 6.4 Return and follow positions primary action to `/positions` and confirm navigation
+- [x] 6.5 Optionally verify responsive width behavior via viewport resize if supported by MCP
+- [x] 6.6 Create report `openspec/changes/scrum-85/reports/2026-05-09-step-6-e2e-playwright.md` documenting scenarios and outcomes
+
+## 7. Update technical documentation (MANDATORY)
+
+- [x] 7.1 If `README.md` or internal frontend docs describe the recruiter dashboard UX, update them to mention grouped sections (only if such references exist — avoid inventing docs)
+- [x] 7.2 Do **not** change `openspec/specs/api-spec.yml` or `openspec/specs/data-model.md` unless an unexpected API touch appears (there should be none)
+
+## 8. Completion checklist
+
+- [x] 8.1 ESLint passes on touched frontend files
+- [x] 8.2 All checklist items above are satisfied before marking tasks complete in this file during apply/verify

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -38,7 +38,8 @@ rules:
   # Rules for backend implementation plans and specs
   spec:
     - When creating backend implementation plans or specs, follow the Backend Implementation Plan Template Structure
-    - All backend plans must include these MANDATORY sections: |
+    - |
+      All backend plans must include these MANDATORY sections:
       1. Header with ticket ID and feature name
       2. Overview with DDD and clean architecture principles
       3. Architecture Context (Domain, Application, Presentation layers)
@@ -51,38 +52,28 @@ rules:
       10. Next Steps After Implementation
       11. Implementation Verification
   
-  # Backend-specific implementation rules
+  # Backend-specific implementation rules (flat strings so YAML parses)
   backend:
-    - Adopt the role of backend-developer when working on backend changes
-    - Apply Domain-Driven Design (DDD) principles
-    - Follow clean architecture with Domain, Application, and Presentation layers
-    - All implementation must follow TDD (Test-Driven Development)
-    - Branch naming: `feature/[ticket-id]-backend` (required, separate from general task branches)
-    - MANDATORY Steps (must be included in all backend implementation plans):
-      - Step 0: Create Feature Branch (must be FIRST step)
-      - Step N: Review and Update Existing Unit Tests (MANDATORY)
-      - Step N+1: Run Unit Tests and Verify Database State (MANDATORY)
-      - Step N+2: Manual Endpoint Testing with curl (MANDATORY)
-      - Step N+3: Update Technical Documentation (MANDATORY)
-    - Common implementation steps:
-      - Step 1: Create Validation Function
-      - Step 2: Create Service Method
-      - Step 3: Create Controller Method
-      - Step 4: Add Route
-      - Step 5: Write Unit Tests (with subcategories: Successful Cases, Validation Errors, Not Found, Reference Validation, Server Errors, Edge Cases)
-    - Testing requirements:
-      - All existing unit tests must be reviewed and updated if necessary
-      - All new unit tests must be created and passing
-      - Full test suite must execute with 0 failures
-      - Test report must be shown and verified
-      - Database state must be properly restored after all tests
-      - All new endpoints must be manually tested using curl
-      - All CREATE/UPDATE/DELETE operations must restore database to original state after testing
-      - Error cases must be tested manually (validation errors, 404, etc.)
-    - Documentation requirements:
-      - Data model changes → Update `openspec/specs/data-model.md`
-      - API endpoint changes → Update `openspec/specs/api-spec.yml`
-      - Standards/libraries/config changes → Update relevant `*-standards.mdc` files
-      - All documentation must be written in English
-    - Error response format must be defined with JSON structure and HTTP status code mapping
-    - Implementation verification checklist must include: Code Quality, Functionality, Testing, Integration, Documentation updates
+    - |
+      Adopt backend-developer role; Domain-Driven Design; clean architecture
+      layers; all implementation follows TDD. Branch naming: feature/[ticket-id]-backend (required).
+    - |
+      MANDATORY steps in backend implementation plans —
+      Step 0: Create Feature Branch (FIRST).
+      Step N: Review and update existing unit tests.
+      Step N+1: Run unit tests and verify database state (with report artifact).
+      Step N+2: Manual endpoint testing with curl.
+      Step N+3: Update technical documentation.
+    - |
+      Common implementation order — validation function, service method,
+      controller method, route, then unit tests (success, validation errors, 404,
+      reference validation, server errors, edge cases).
+    - |
+      Testing — review/update all impacted tests; new tests passing; full suite green;
+      restore database after tests; manual curl on new endpoints;
+      CREATE/UPDATE/DELETE tests restore DB; cover validation and 404 errors.
+    - |
+      Documentation — data-model changes → openspec/specs/data-model.md;
+      API changes → openspec/specs/api-spec.yml; standards changes → relevant *-standards.mdc; English only.
+    - Error responses must specify JSON bodies and HTTP status mapping.
+    - Verification checklist covers code quality, functionality, testing, integration, documentation updates.

--- a/openspec/specs/recruiter-dashboard-layout/spec.md
+++ b/openspec/specs/recruiter-dashboard-layout/spec.md
@@ -1,0 +1,71 @@
+# recruiter-dashboard-layout Specification
+
+## Purpose
+
+Defines recruiter home (`/`) layout: grouped candidate vs position workflows, responsive structure, dashboard i18n, and no extra backend coupling for the landing page alone.
+## Requirements
+### Requirement: Recruiter home page groups candidate and position actions
+
+The system SHALL render the recruiter dashboard at route `/` with two distinct groups: one for **candidate-related** actions and one for **position-related** actions. Each group SHALL include a visible section title and at least one primary navigation control. The candidate group SHALL provide access to add a candidate (navigate to `/add-candidate`). The position group SHALL provide access to the positions list (navigate to `/positions`).
+
+#### Scenario: Candidate group links to add candidate
+
+- **WHEN** the user views `/`
+- **THEN** a candidate workflow section is visible and includes a control that navigates to `/add-candidate`
+
+#### Scenario: Position group links to positions list
+
+- **WHEN** the user views `/`
+- **THEN** a position workflow section is visible and includes a control that navigates to `/positions`
+
+#### Scenario: Sections are distinguishable from each other
+
+- **WHEN** the dashboard is rendered
+- **THEN** candidate and position groups are visually separated by section headings and/or spacing so a typical user can tell which actions belong to which workflow
+
+### Requirement: Dashboard layout and responsiveness
+
+The dashboard SHALL use React Bootstrap and Bootstrap patterns consistent with `docs/frontend-standards.md`. Content SHALL be usable on narrow viewports (stacked layout, adequate spacing and touch targets) and on `md` and wider viewports (clear multi-column or structured layout without horizontal overflow).
+
+#### Scenario: Narrow viewport stacks content
+
+- **WHEN** the viewport width is below the `md` breakpoint
+- **THEN** section groups stack vertically and remain readable without horizontal scrolling
+
+#### Scenario: Wider viewport shows structured layout
+
+- **WHEN** the viewport width is at or above the `md` breakpoint
+- **THEN** the page presents a clear structured layout (e.g. two columns or equivalent) that preserves both workflow groups
+
+### Requirement: Internationalization for new dashboard copy
+
+All new or changed user-visible strings on the recruiter dashboard SHALL be defined under the `dashboard` namespace in both `frontend/src/i18n/locales/en.json` and `frontend/src/i18n/locales/es.json` with identical key structure. The component SHALL resolve them through `useTranslation()` and `t()`.
+
+#### Scenario: English and Spanish keys exist for new strings
+
+- **WHEN** a new translation key is added for dashboard section titles or descriptions
+- **THEN** the same key path exists in both `en.json` and `es.json` with non-empty values
+
+### Requirement: Accessible structure for the recruiter dashboard
+
+The page SHALL expose a logical heading hierarchy: exactly one primary page title suitable for `h1`, and section titles for each workflow group using heading elements (e.g. `h2`). Links SHALL have descriptive visible text or accessible names so purpose is clear out of context.
+
+#### Scenario: Heading hierarchy is logical
+
+- **WHEN** assistive technology reads the `/` page
+- **THEN** a single primary document title precedes section headings for candidate and position groups in a logical order
+
+#### Scenario: Primary actions have clear names
+
+- **WHEN** the user inspects candidate and position primary links or buttons
+- **THEN** each target’s purpose is clear from its label (via `t()`-resolved text or equivalent)
+
+### Requirement: No new backend coupling on the dashboard
+
+The recruiter dashboard SHALL NOT introduce new HTTP requests or dependency on new backend endpoints solely for this change. Existing client-side routing and downstream pages remain responsible for API usage.
+
+#### Scenario: Dashboard renders without fetching dashboard-specific data
+
+- **WHEN** the user loads `/` with the application in a normal running state
+- **THEN** the dashboard does not require new API endpoints introduced by SCRUM-85 to render grouped sections and links
+


### PR DESCRIPTION
## Summary

- Restyle the recruiter home page (`/`) into clear **Candidates** and **Positions** sections (headings, lead text, Bootstrap layout, decorative icons).
- Add `dashboard.sections.*` i18n keys in English and Spanish; extend `RecruiterDashboard` RTL tests.

## OpenSpec

- Archive `scrum-85` to `openspec/changes/archive/2026-05-09-scrum-85/`.
- Merge main capability **recruiter-dashboard-layout** under `openspec/specs/recruiter-dashboard-layout/spec.md`.

## Tooling

- Fix `openspec/config.yaml` YAML parsing issues so the openspec CLI runs without errors.

## Out of scope in this PR

Other local edits (skills, docs, `.gitignore`) remain unstaged in the working tree.

Made with [Cursor](https://cursor.com)