### PR TITLE
[SCRUM-86] Add create interview for candidate

### DIFF
--- a/.claude/doc/create-interview/backend.md
+++ b/.claude/doc/create-interview/backend.md
@@ -1,0 +1,838 @@
+# Backend Implementation Plan: Create Interview (SCRUM-86)
+
+## Overview
+
+Add a `POST /candidates/{candidateId}/interviews` endpoint that creates a new interview for one of the candidate's existing applications. The `Interview` domain model already has the insert path via `save()` when `id` is absent — no schema migration is needed.
+
+The implementation mirrors the existing edit/delete interview patterns exactly.
+
+---
+
+## Working Directory
+
+All paths are relative to:
+`/Users/alvaromoya/projects/versiones ejercicios/AI4Devs-LTI-before-position-update-openspec-raw-2026/.worktrees/SCRUM-86`
+
+---
+
+## Step 0: Create Feature Branch
+
+```bash
+git checkout -b feature/SCRUM-86-create-interview
+```
+
+Run from the worktree root. The worktree is already on branch `main` (not `SCRUM-86`). The sub-branch keeps the feature work isolated.
+
+Mark tasks.md: 0.1, 0.2
+
+---
+
+## Step 1 + 2: Validator — Test File First, Then Implementation
+
+### New test file
+
+**Path**: `backend/src/application/__tests__/validator.createInterview.test.ts`
+
+Follow the naming convention from the existing test files:
+- `backend/src/application/__tests__/validator.test.ts` (existing — covers `validateInterviewUpdateData` and `validatePositionUpdateData`)
+- `backend/src/application/validator.assignCandidate.test.ts` (existing flat sibling, not in `__tests__/`)
+
+The new test file goes inside `__tests__/` to match the more recent pattern used by the interviewService tests.
+
+**Import**:
+```typescript
+import { validateInterviewCreateData } from '../validator';
+```
+
+**Test structure** (use `describe` + `it` blocks, AAA pattern):
+
+```typescript
+describe('validateInterviewCreateData', () => {
+  describe('Valid payloads', () => {
+    it('accepts full valid payload (all fields)');        // task 1.1
+    it('accepts minimal valid payload (required only)'); // task 1.2
+  });
+
+  describe('Missing required fields', () => {
+    it('throws when applicationId is missing');    // task 1.3
+    it('throws when interviewStepId is missing');  // task 1.4
+    it('throws when employeeId is missing');       // task 1.5
+    it('throws when interviewDate is missing');    // task 1.6
+  });
+
+  describe('Non-integer FK fields', () => {
+    it('throws when applicationId is not a positive integer');   // task 1.7
+    it('throws when interviewStepId is not a positive integer'); // task 1.7
+    it('throws when employeeId is not a positive integer');      // task 1.7
+  });
+
+  describe('interviewDate format', () => {
+    it('throws when interviewDate is not valid ISO 8601');  // task 1.8
+    it('throws when interviewDate is date-only (no T)');   // task 1.8
+  });
+
+  describe('score validation', () => {
+    it('throws when score < 0');   // task 1.9
+    it('throws when score > 5');   // task 1.9
+    it('accepts score = null');    // task 1.9
+    it('accepts score = 0 and 5'); // boundary
+  });
+
+  describe('notes validation', () => {
+    it('throws when notes.length > 1000');  // task 1.10
+    it('accepts notes = null');             // task 1.10
+    it('accepts notes = "" (empty ok)');
+  });
+
+  describe('result validation', () => {
+    it('throws when result is an invalid string');          // task 1.11
+    it('accepts result = "Pending"');                       // task 1.11
+    it('accepts result = "Passed"');                        // task 1.11
+    it('accepts result = "Failed"');                        // task 1.11
+    it('accepts result = null');                            // task 1.11
+    it('accepts result omitted (undefined)');
+  });
+
+  describe('allow-list (unexpected fields)', () => {
+    it('throws when unexpected field is present');  // task 1.12
+    it('throws when null/undefined body provided');
+  });
+});
+```
+
+All tests must be written BEFORE the implementation (TDD). They will fail on import since `validateInterviewCreateData` does not exist yet.
+
+### Implementation in `validator.ts`
+
+**Path**: `backend/src/application/validator.ts`
+
+Add `validateInterviewCreateData` after `validateInterviewDeletion`. Export it.
+
+**Allow-list constant** (place near the top of the create block):
+```typescript
+const INTERVIEW_CREATE_ALLOWED_FIELDS = [
+  'applicationId',
+  'interviewStepId',
+  'employeeId',
+  'interviewDate',
+  'result',
+  'score',
+  'notes',
+];
+```
+
+**Function signature**:
+```typescript
+export const validateInterviewCreateData = (data: any): void => { ... }
+```
+
+**Validation order** (mirrors `validateAssignCandidateToPositionData` for allow-list; mirrors `validateInterviewUpdateData` for field rules):
+
+1. **Null/undefined/non-object body check** — throw `'Request body is required'`
+2. **Allow-list check** — iterate `Object.keys(data)`, throw `'Unexpected field: {key}'` for any key not in `INTERVIEW_CREATE_ALLOWED_FIELDS`
+3. **Required: `applicationId`** — undefined/null → `'applicationId is required'`; not positive integer → `'applicationId must be a positive integer'`
+4. **Required: `interviewStepId`** — undefined/null → `'interviewStepId is required'`; not positive integer → `'interviewStepId must be a positive integer'`
+5. **Required: `employeeId`** — undefined/null → `'employeeId is required'`; not positive integer → `'employeeId must be a positive integer'`
+6. **Required: `interviewDate`** — undefined/null → `'interviewDate is required'`; not string or not ISO 8601 with T → `'interviewDate must be valid ISO 8601'` (reuse the existing `isValidISO8601DateTime` helper already in the file)
+7. **Optional: `score`** — if present and not null: not integer or < 0 or > 5 → `'Score must be between 0 and 5'`
+8. **Optional: `notes`** — if present and not null: not string → `'notes must be a string'`; length > 1000 → `'Notes must not exceed 1000 characters'`
+9. **Optional: `result`** — if present and not null: not string → `'result must be a string'`; not in `INTERVIEW_RESULT_VALUES` → `'Invalid result value'` (reuse the existing constant `INTERVIEW_RESULT_VALUES = ['Pending', 'Passed', 'Failed']` already in the file)
+
+**Important**: `isValidISO8601DateTime` and `INTERVIEW_RESULT_VALUES` already exist in `validator.ts`. Do NOT redefine them. The new function simply calls them.
+
+---
+
+## Step 3 + 4: Service — Test File First, Then Implementation
+
+### New test file
+
+**Path**: `backend/src/application/services/__tests__/interviewService.createInterview.test.ts`
+
+Naming mirrors `interviewService.test.ts` (already contains `updateInterview` + `deleteInterview` tests).
+
+**Mocking pattern** (copy exactly from `interviewService.test.ts`):
+```typescript
+jest.mock('@prisma/client', () => {
+  const mockPrisma = {
+    interview: {
+      create: jest.fn(),
+      update: jest.fn(),
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+  return { PrismaClient: jest.fn(() => mockPrisma) };
+});
+
+jest.mock('../../../domain/models/Candidate');
+jest.mock('../../../domain/models/Application');
+jest.mock('../../../domain/models/Position');
+jest.mock('../../../domain/models/InterviewStep');
+jest.mock('../../../domain/models/Employee');
+jest.mock('../../../domain/models/Interview');
+```
+
+**Import**:
+```typescript
+import { createInterview } from '../interviewService';
+import { Candidate } from '../../../domain/models/Candidate';
+import { Application } from '../../../domain/models/Application';
+import { Position } from '../../../domain/models/Position';
+import { InterviewStep } from '../../../domain/models/InterviewStep';
+import { Employee } from '../../../domain/models/Employee';
+import { Interview } from '../../../domain/models/Interview';
+import { PrismaClient } from '@prisma/client';
+```
+
+**Test structure**:
+
+```typescript
+describe('createInterview', () => {
+  describe('Successful interview creation', () => {
+    it('creates interview with all fields');                   // task 3.1
+    it('creates interview with minimal fields — result defaults to Pending'); // task 3.2
+  });
+
+  describe('Candidate not found', () => {
+    it('throws "Candidate not found" when candidateId does not exist'); // task 3.3
+  });
+
+  describe('Application not found / not owned', () => {
+    it('throws "Application not found" when applicationId does not exist');          // task 3.4
+    it('throws with not-found message when application belongs to different candidate'); // task 3.5
+  });
+
+  describe('Interview step validation', () => {
+    it('throws "Interview step not found" when stepId does not exist');             // task 3.6
+    it('throws step-not-in-flow message when step belongs to different flow');      // task 3.7
+  });
+
+  describe('Employee validation', () => {
+    it('throws "Employee not found" when employeeId does not exist');  // task 3.8
+    it('throws "Employee is not active" when isActive = false');        // task 3.9
+  });
+
+  describe('Persistence error', () => {
+    it('re-throws database error from save()');  // task 3.10
+  });
+});
+```
+
+**Key mocking pattern for successful creation** (mirrors `updateInterview` tests):
+```typescript
+const mockCreatedData = { id: 99, applicationId: 1, ... };
+const mockInterviewInstance = {
+  save: jest.fn().mockResolvedValue(mockCreatedData),
+};
+(Interview as unknown as jest.Mock).mockImplementation(() => mockInterviewInstance);
+```
+
+The `new Interview({...})` constructor mock returns `mockInterviewInstance`, whose `save()` returns the created record. The service then wraps that in `new Interview(savedData)` — the second call also returns `mockInterviewInstance` (same mock).
+
+**Verify in the success test**:
+- `Candidate.findOne` called with `candidateId`
+- `Application.findOne` called with `applicationId`
+- `Position.findOne` called with `application.positionId`
+- `InterviewStep.findOne` called with `interviewStepId`
+- `Employee.findOne` called with `employeeId`
+- `Interview` constructor called without `id` field
+- `mockInterviewInstance.save` called once
+- Returned object has expected shape
+
+### Implementation in `interviewService.ts`
+
+**Path**: `backend/src/application/services/interviewService.ts`
+
+Add `createInterview` exported function. Do NOT touch existing `updateInterview` or `deleteInterview`.
+
+**Signature**:
+```typescript
+export const createInterview = async (
+  candidateId: number,
+  interviewData: any
+): Promise<Interview> => { ... }
+```
+
+**Business-rule validation order** (strict — fail before writing):
+
+1. **Candidate exists**
+   ```typescript
+   const candidate = await Candidate.findOne(candidateId);
+   if (!candidate) throw new Error('Candidate not found');
+   ```
+
+2. **Application exists AND belongs to candidate**
+   ```typescript
+   const application = await Application.findOne(interviewData.applicationId);
+   if (!application) throw new Error('Application not found');
+   if (application.candidateId !== candidateId) {
+     throw new Error('Application does not belong to the specified candidate');
+   }
+   ```
+
+3. **Position lookup** (needed for flow check)
+   ```typescript
+   const position = await Position.findOne(application.positionId);
+   if (!position) throw new Error('Position not found');
+   ```
+
+4. **Interview step exists AND belongs to position's flow**
+   ```typescript
+   const interviewStep = await InterviewStep.findOne(interviewData.interviewStepId);
+   if (!interviewStep) throw new Error('Interview step not found');
+   if (interviewStep.interviewFlowId !== position.interviewFlowId) {
+     throw new Error("Interview step does not belong to the position's interview flow");
+   }
+   ```
+
+5. **Employee exists AND is active**
+   ```typescript
+   const employee = await Employee.findOne(interviewData.employeeId);
+   if (!employee) throw new Error('Employee not found');
+   if (!employee.isActive) throw new Error('Employee is not active');
+   ```
+
+6. **Apply `result` default**
+   ```typescript
+   const result = interviewData.result ?? 'Pending';
+   ```
+
+7. **Construct + save**
+   ```typescript
+   const newInterview = new Interview({
+     applicationId: interviewData.applicationId,
+     interviewStepId: interviewData.interviewStepId,
+     employeeId: interviewData.employeeId,
+     interviewDate: interviewData.interviewDate,
+     result,
+     score: interviewData.score,
+     notes: interviewData.notes,
+   });
+   // Note: no `id` field — save() will branch to prisma.interview.create()
+   ```
+
+8. **Persist with try/catch**
+   ```typescript
+   try {
+     const savedInterview = await newInterview.save();
+     return new Interview(savedInterview);
+   } catch (error: any) {
+     throw new Error(error.message || 'Failed to create interview');
+   }
+   ```
+
+**Important error messages** — controller maps these substrings to HTTP codes:
+- `'not found'` (case-insensitive substring match) → 404
+- `'is not active'` → 400
+- `"does not belong to the position's interview flow"` → 400
+
+The exact strings in the service MUST contain these substrings. Check the controller error mapping table in Step 6 before finalising.
+
+---
+
+## Step 5 + 6: Controller — Test File First, Then Implementation
+
+### New test file
+
+**Path**: `backend/src/presentation/controllers/__tests__/interviewController.createInterview.test.ts`
+
+Mirrors the existing `interviewController.test.ts` structure. Note: the existing file covers both `updateInterviewController` and `deleteInterviewController` in one file. New tests go in a new sibling file.
+
+**Mocking pattern**:
+```typescript
+jest.mock('../../../application/services/interviewService');
+jest.mock('../../../application/validator');
+
+import { createInterview } from '../../../application/services/interviewService';
+import { validateInterviewCreateData } from '../../../application/validator';
+
+const mockCreateInterview = createInterview as jest.MockedFunction<typeof createInterview>;
+const mockValidateInterviewCreateData = validateInterviewCreateData as jest.MockedFunction<typeof validateInterviewCreateData>;
+```
+
+**Request/Response mock setup** (same as existing test):
+```typescript
+let mockRequest: Partial<Request>;
+let mockResponse: Partial<Response>;
+let mockJson: jest.Mock;
+let mockStatus: jest.Mock;
+
+beforeEach(() => {
+  mockJson = jest.fn();
+  mockStatus = jest.fn().mockReturnThis();
+  mockResponse = { json: mockJson, status: mockStatus };
+  mockRequest = { params: {}, body: {} };
+  jest.clearAllMocks();
+});
+```
+
+**Test structure**:
+
+```typescript
+describe('createInterviewController', () => {
+  describe('Successful creation', () => {
+    it('returns 201 with created interview on success');  // task 5.1
+  });
+
+  describe('Invalid candidateId format', () => {
+    it('returns 400 when candidateId is not numeric');  // task 5.2
+  });
+
+  describe('Validator errors', () => {
+    it('returns 400 when validator throws');  // task 5.3
+  });
+
+  describe('Not found errors', () => {
+    it('returns 404 when service throws "Candidate not found"');              // task 5.4
+    it('returns 404 when service throws "Application not found"');            // task 5.5
+    it('returns 404 when service throws "does not belong to the specified"'); // task 5.5
+    it('returns 404 when service throws "Interview step not found"');         // task 5.6
+    it('returns 404 when service throws "Employee not found"');               // task 5.8
+  });
+
+  describe('Business rule errors (400)', () => {
+    it('returns 400 when service throws step-not-in-flow message');  // task 5.7
+    it('returns 400 when service throws "is not active" message');   // task 5.9
+  });
+
+  describe('Server errors', () => {
+    it('returns 500 when service throws unexpected error');  // task 5.10
+  });
+});
+```
+
+**Success test specifics**:
+```typescript
+mockRequest.params = { candidateId: '1' };
+mockRequest.body = { applicationId: 2, interviewStepId: 3, employeeId: 4, interviewDate: '2026-06-20T10:00:00Z' };
+mockValidateInterviewCreateData.mockImplementation(() => {});
+mockCreateInterview.mockResolvedValue(mockCreatedInterview as any);
+
+// Verify:
+expect(mockValidateInterviewCreateData).toHaveBeenCalledWith(mockRequest.body);
+expect(mockCreateInterview).toHaveBeenCalledWith(1, mockRequest.body);
+expect(mockStatus).toHaveBeenCalledWith(201);
+expect(mockJson).toHaveBeenCalledWith(mockCreatedInterview);
+```
+
+### Implementation in `interviewController.ts`
+
+**Path**: `backend/src/presentation/controllers/interviewController.ts`
+
+Add `createInterviewController` to the existing file. Add these imports at the top:
+```typescript
+import { updateInterview, deleteInterview, createInterview } from '../../application/services/interviewService';
+import { validateInterviewUpdateData, validateInterviewDeletion, validateInterviewCreateData } from '../../application/validator';
+```
+
+**Function**:
+```typescript
+export const createInterviewController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const candidateId = parseInt(req.params.candidateId);
+    if (isNaN(candidateId)) {
+      return res.status(400).json({
+        message: 'Validation error',
+        error: 'Invalid candidate ID format',
+      });
+    }
+
+    const interviewData = req.body;
+
+    try {
+      validateInterviewCreateData(interviewData);
+    } catch (validationError: any) {
+      return res.status(400).json({
+        message: 'Validation error',
+        error: validationError.message,
+      });
+    }
+
+    const createdInterview = await createInterview(candidateId, interviewData);
+
+    return res.status(201).json(createdInterview);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      // Business rule violations → 400 (check BEFORE generic not-found)
+      if (
+        error.message.includes("does not belong to the position's interview flow") ||
+        error.message.includes('is not active')
+      ) {
+        return res.status(400).json({
+          message: 'Validation error',
+          error: error.message,
+        });
+      }
+
+      // Not found → 404
+      if (error.message.includes('not found') || error.message.includes('does not belong')) {
+        return res.status(404).json({
+          message: 'Resource not found',
+          error: error.message,
+        });
+      }
+
+      // Unexpected → 500
+      return res.status(500).json({
+        message: 'Internal server error',
+        error: 'An unexpected error occurred',
+      });
+    }
+
+    return res.status(500).json({
+      message: 'Internal server error',
+      error: 'An unexpected error occurred',
+    });
+  }
+};
+```
+
+**Error mapping logic**: The 400-before-404 ordering is critical. The message `"does not belong to the position's interview flow"` contains `'does not belong'`, which would also match the 404 branch — so the 400 check MUST come first. This mirrors `updateInterviewController` exactly.
+
+---
+
+## Step 7: Route Registration + Integration Test
+
+### `candidateRoutes.ts` change
+
+**Path**: `backend/src/routes/candidateRoutes.ts`
+
+1. Add `createInterviewController` to the import line:
+   ```typescript
+   import { updateInterviewController, deleteInterviewController, createInterviewController } from '../presentation/controllers/interviewController';
+   ```
+
+2. Register the route BEFORE the existing `/:id` route. Insert it alongside the other interview routes:
+   ```typescript
+   // Interview routes — must be before /:id to avoid route conflicts
+   router.post('/:candidateId/interviews', createInterviewController);      // NEW
+   router.patch('/:candidateId/interviews/:interviewId', updateInterviewController);
+   router.delete('/:candidateId/interviews/:interviewId', deleteInterviewController);
+   ```
+
+   The `POST` route must come before `router.get('/:id', getCandidateById)`.
+
+### Integration test
+
+**Path**: `backend/src/routes/candidateRoutes.createInterview.integration.test.ts`
+
+Model after `positionRoutes.integration.test.ts` (uses `express` + `supertest`, mocks service + validator).
+
+```typescript
+import express from 'express';
+import request from 'supertest';
+import candidateRoutes from './candidateRoutes';
+import { createInterview } from '../application/services/interviewService';
+import { validateInterviewCreateData } from '../application/validator';
+
+jest.mock('../application/services/interviewService', () => ({
+  createInterview: jest.fn(),
+  updateInterview: jest.fn(),
+  deleteInterview: jest.fn(),
+}));
+
+jest.mock('../application/validator', () => ({
+  validateInterviewCreateData: jest.fn(),
+  validateInterviewUpdateData: jest.fn(),
+  validateInterviewDeletion: jest.fn(),
+  validateCandidateData: jest.fn(),
+}));
+
+// Also mock domain models used by controllers imported transitively:
+jest.mock('../domain/models/Candidate');
+jest.mock('../domain/models/Application');
+// ... (add others if TypeScript errors appear at import time)
+
+describe('POST /candidates/:candidateId/interviews integration', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/candidates', candidateRoutes);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns 201 on successful create');
+  it('returns 400 on invalid candidateId');
+  it('returns 400 on validator throw');
+  it('returns 404 on candidate not found');
+  it('returns 400 on step not in flow');
+  it('returns 500 on unexpected error');
+});
+```
+
+**Note on mock scope for integration test**: `candidateRoutes.ts` imports `addCandidate`, `getCandidateById`, etc. from `candidateController`. Those controllers import Prisma-backed domain models. Mock the entire controller module OR all domain models to avoid real DB connections in tests. The safest approach is to mock the service + validator as above, since the controller delegates entirely to them after ID parsing. If import-time Prisma errors appear, add `jest.mock('../presentation/controllers/candidateController')` as a fallback.
+
+---
+
+## Step 8: Review Existing Tests
+
+Check these files for any test that mocks the import list of `interviewController.ts` or `interviewService.ts`:
+
+- `backend/src/presentation/controllers/__tests__/interviewController.test.ts`
+  - Currently imports `updateInterview, deleteInterview` and `validateInterviewUpdateData, validateInterviewDeletion`.
+  - After Step 6, the controller will import `createInterview` and `validateInterviewCreateData` too.
+  - The existing test mocks the entire module: `jest.mock('../../../application/services/interviewService')` — this auto-mocks all exports including the new `createInterview`. **No change needed** as long as the mock uses `jest.mock` without manual `moduleNameMapper`.
+
+- `backend/src/application/services/__tests__/interviewService.test.ts`
+  - Tests `updateInterview` and `deleteInterview`.
+  - Adding `createInterview` to the same file does NOT break existing tests.
+  - If the test file's import line is: `import { updateInterview, deleteInterview } from '../interviewService';` — it only imports what it needs and will remain unaffected.
+
+**Likely no changes needed** to existing test files, but verify after implementation.
+
+---
+
+## Step 9: Run Tests and Verification Report
+
+Commands to run from the worktree root:
+```bash
+cd backend && npm test
+```
+
+Or targeted:
+```bash
+cd backend && npm test -- --testPathPattern="validator.createInterview|interviewService.createInterview|interviewController.createInterview|candidateRoutes.createInterview"
+```
+
+Create report at:
+`openspec/changes/create-interview/specs/create-interview/reports/2026-06-09-step-9-unit-test-and-db-verification.md`
+
+The directory does not exist yet — create it first:
+```bash
+mkdir -p openspec/changes/create-interview/specs/create-interview/reports
+```
+
+---
+
+## Step 10: Manual curl Testing
+
+Start backend:
+```bash
+cd backend && npm run dev
+```
+
+Key curl commands to cover:
+
+**201 success (full payload)**:
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z","result":"Pending","score":4,"notes":"Test"}'
+```
+
+**201 success (minimal — result defaults to Pending)**:
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**400 — invalid candidateId**:
+```bash
+curl -s -X POST http://localhost:3010/candidates/abc/interviews \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+**400 — missing required field**:
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**400 — unexpected field**:
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z","unknownField":"x"}'
+```
+
+**404 — candidate not found**:
+```bash
+curl -s -X POST http://localhost:3010/candidates/999999/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+After each successful 201, delete the created record using the existing DELETE endpoint to restore DB state.
+
+Document results in: `openspec/changes/create-interview/specs/create-interview/reports/CURL_TESTING.md`
+
+---
+
+## Step 16: API Documentation Update
+
+**Path**: `docs/api-spec.yml`
+
+The existing `PATCH /candidates/{candidateId}/interviews/{interviewId}` is at line ~204.
+
+Add a new path entry `POST /candidates/{candidateId}/interviews` BEFORE the existing `PATCH/DELETE` block (it is a different path — `/candidates/{candidateId}/interviews` not `/{interviewId}`):
+
+```yaml
+  /candidates/{candidateId}/interviews:
+    post:
+      summary: Create a new interview
+      description: Creates a new interview for one of the candidate's applications.
+      tags:
+        - Candidates
+      parameters:
+        - in: path
+          name: candidateId
+          required: true
+          schema:
+            type: integer
+          description: ID of the candidate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateInterviewRequest'
+      responses:
+        '201':
+          description: Interview created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewResponse'
+        '400':
+          description: Validation error or business rule violation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Candidate, application, interview step, or employee not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+```
+
+Add `CreateInterviewRequest` schema in the `components/schemas` section (near `UpdateInterviewRequest` at line ~1437):
+
+```yaml
+    CreateInterviewRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - applicationId
+        - interviewStepId
+        - employeeId
+        - interviewDate
+      properties:
+        applicationId:
+          type: integer
+          minimum: 1
+        interviewStepId:
+          type: integer
+          minimum: 1
+        employeeId:
+          type: integer
+          minimum: 1
+        interviewDate:
+          type: string
+          format: date-time
+        result:
+          type: string
+          nullable: true
+          enum: [Pending, Passed, Failed]
+        score:
+          type: integer
+          nullable: true
+          minimum: 0
+          maximum: 5
+        notes:
+          type: string
+          maxLength: 1000
+          nullable: true
+```
+
+`InterviewResponse` (already defined at line ~1410) is reused for the 201 body — no changes needed.
+
+Check whether `openspec/specs/api-spec.yml` exists and if so mirror the same changes there (task 16.6). Based on `ls openspec/specs/`, the folder has subdirectories but the file may not exist — verify before acting.
+
+---
+
+## File Summary
+
+### Files to CREATE (new)
+
+| File | Purpose |
+|------|---------|
+| `backend/src/application/__tests__/validator.createInterview.test.ts` | Validator tests (TDD — write first) |
+| `backend/src/application/services/__tests__/interviewService.createInterview.test.ts` | Service tests (TDD — write first) |
+| `backend/src/presentation/controllers/__tests__/interviewController.createInterview.test.ts` | Controller tests (TDD — write first) |
+| `backend/src/routes/candidateRoutes.createInterview.integration.test.ts` | Integration test |
+| `openspec/changes/create-interview/specs/create-interview/reports/2026-06-09-step-9-unit-test-and-db-verification.md` | Test run report |
+| `openspec/changes/create-interview/specs/create-interview/reports/CURL_TESTING.md` | curl test results |
+
+### Files to MODIFY
+
+| File | Change |
+|------|--------|
+| `backend/src/application/validator.ts` | Add `validateInterviewCreateData` export and `INTERVIEW_CREATE_ALLOWED_FIELDS` constant |
+| `backend/src/application/services/interviewService.ts` | Add `createInterview` export |
+| `backend/src/presentation/controllers/interviewController.ts` | Add `createInterviewController` export; update imports |
+| `backend/src/routes/candidateRoutes.ts` | Import `createInterviewController`; register `router.post('/:candidateId/interviews', ...)` before `/:id` |
+| `docs/api-spec.yml` | Add `POST /candidates/{candidateId}/interviews` path + `CreateInterviewRequest` schema |
+| `openspec/changes/create-interview/tasks.md` | Mark tasks `[x]` as completed |
+
+### Files NOT to touch
+
+- `backend/src/domain/models/Interview.ts` — already supports insert via `save()` when no `id`
+- `backend/prisma/schema.prisma` — no migration needed
+- Any existing test files (unless they fail after the changes are in place)
+
+---
+
+## Critical Implementation Notes
+
+### 1. Error message substrings must be stable
+
+The controller's error-mapping uses `includes()` string checks. The service MUST throw errors with these exact substrings:
+
+| Service error message | Controller check | HTTP code |
+|---|---|---|
+| `'Candidate not found'` | `.includes('not found')` | 404 |
+| `'Application not found'` | `.includes('not found')` | 404 |
+| `'Application does not belong to the specified candidate'` | `.includes('does not belong')` | 404 |
+| `'Interview step not found'` | `.includes('not found')` | 404 |
+| `"Interview step does not belong to the position's interview flow"` | `.includes("does not belong to the position's interview flow")` first, then `.includes('does not belong')` would also match 404 — **the 400 check is first in the if-else chain** | 400 |
+| `'Employee not found'` | `.includes('not found')` | 404 |
+| `'Employee is not active'` | `.includes('is not active')` | 400 |
+
+The 400-before-404 ordering in the catch block is required to avoid the step-not-in-flow message routing to 404.
+
+### 2. No `id` in the Interview constructor for create
+
+When calling `new Interview({...})` in `createInterview`, omit the `id` field entirely (do not pass `id: undefined`). The `save()` method checks `if (this.id)` — passing `undefined` is equivalent to not passing it, but for clarity and to mirror the domain's intent, leave it out of the object literal.
+
+### 3. Route registration order matters
+
+In `candidateRoutes.ts`, Express matches routes in declaration order. `router.post('/:candidateId/interviews', ...)` must be registered BEFORE `router.get('/:id', ...)`. The current file already has PATCH and DELETE interview routes before `/:id` — add POST alongside them.
+
+### 4. Pre-existing compile failures in positionController.ts
+
+There are 4 pre-existing compile errors in `positionController.ts` (missing `validateAssignCandidateToPositionData` and `assignCandidateToPositionService`). These will appear in the full test run but are not caused by this change. Do not fix them unless they block specific test files from running.
+
+### 5. Test file locations
+
+Two naming conventions exist in the codebase:
+- Flat siblings: `validator.assignCandidate.test.ts` (beside `validator.ts`)
+- `__tests__/` subdirectories: `__tests__/validator.test.ts`, `__tests__/interviewService.test.ts`
+
+New test files for this feature use the `__tests__/` pattern for both the validator and service tests, matching the newest pattern. The controller test also goes in `__tests__/` (existing `interviewController.test.ts` is already there).
+
+### 6. `result` default is applied in the SERVICE, not the validator
+
+The validator accepts `result` as optional (undefined passes). The service applies `result ?? 'Pending'` before constructing the Interview. The validator only rejects invalid values when result IS provided.
+
+### 7. ISO 8601 validation reuses existing helper
+
+`isValidISO8601DateTime` is already defined at line 114 of `validator.ts`. It requires the string to include `'T'` (date-only values are rejected). The `validateInterviewCreateData` function calls this helper for `interviewDate` — do not duplicate the logic.

--- a/backend/src/application/__tests__/validator.test.ts
+++ b/backend/src/application/__tests__/validator.test.ts
@@ -1,4 +1,4 @@
-import { validatePositionUpdateData, validateInterviewUpdateData, validateInterviewDeletion, validateCandidatePositionDeletion } from '../validator';
+import { validatePositionUpdateData, validateInterviewUpdateData, validateInterviewDeletion, validateCandidatePositionDeletion, validateInterviewCreateData } from '../validator';
 
 describe('validatePositionUpdateData', () => {
     describe('Valid update data scenarios', () => {
@@ -814,6 +814,350 @@ describe('validateInterviewDeletion', () => {
             };
 
             expect(() => validateInterviewDeletion(candidateId, interviewId, deletionData)).not.toThrow();
+        });
+    });
+});
+
+describe('validateInterviewCreateData', () => {
+    describe('Valid payload scenarios', () => {
+        it('should not throw for a valid full payload with all fields', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                result: 'Pending',
+                score: 4,
+                notes: 'Strong technical candidate'
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should not throw for a valid minimal payload (result omitted)', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should not throw when score is null', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                score: null
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should not throw when notes is null', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                notes: null
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+    });
+
+    describe('Missing required fields', () => {
+        it('should throw when applicationId is missing', () => {
+            const invalidData = {
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('applicationId is required');
+        });
+
+        it('should throw when interviewStepId is missing', () => {
+            const invalidData = {
+                applicationId: 1,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('interviewStepId is required');
+        });
+
+        it('should throw when employeeId is missing', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('employeeId is required');
+        });
+
+        it('should throw when interviewDate is missing', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('interviewDate is required');
+        });
+    });
+
+    describe('Non-integer FK fields', () => {
+        it('should throw when applicationId is not an integer', () => {
+            const invalidData = {
+                applicationId: '1',
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('applicationId must be a positive integer');
+        });
+
+        it('should throw when applicationId is a float', () => {
+            const invalidData = {
+                applicationId: 1.5,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('applicationId must be a positive integer');
+        });
+
+        it('should throw when interviewStepId is not an integer', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: '2',
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('interviewStepId must be a positive integer');
+        });
+
+        it('should throw when employeeId is not an integer', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: '3',
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('employeeId must be a positive integer');
+        });
+
+        it('should throw when applicationId is zero or negative', () => {
+            const invalidData = {
+                applicationId: 0,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('applicationId must be a positive integer');
+        });
+    });
+
+    describe('Invalid interviewDate format', () => {
+        it('should throw when interviewDate is not ISO 8601 (date-only format)', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('interviewDate must be valid ISO 8601');
+        });
+
+        it('should throw when interviewDate is not a valid date string', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: 'not-a-date'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('interviewDate must be valid ISO 8601');
+        });
+
+        it('should throw when interviewDate is not a string', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: 1234567890
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow();
+        });
+    });
+
+    describe('Score validation', () => {
+        it('should throw when score is less than 0', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                score: -1
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('Score must be between 0 and 5');
+        });
+
+        it('should throw when score is greater than 5', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                score: 6
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('Score must be between 0 and 5');
+        });
+
+        it('should accept score of 0', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                score: 0
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should accept score of 5', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                score: 5
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should accept null score', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                score: null
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+    });
+
+    describe('Notes validation', () => {
+        it('should throw when notes exceeds 1000 characters', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                notes: 'a'.repeat(1001)
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('Notes must not exceed 1000 characters');
+        });
+
+        it('should accept notes with exactly 1000 characters', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                notes: 'a'.repeat(1000)
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should accept null notes', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                notes: null
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+    });
+
+    describe('Result validation', () => {
+        it('should accept result "Pending"', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                result: 'Pending'
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should accept result "Passed"', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                result: 'Passed'
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should accept result "Failed"', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                result: 'Failed'
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+
+        it('should throw when result is an invalid value', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                result: 'InvalidResult'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('Invalid result value');
+        });
+
+        it('should accept null result (will default to Pending downstream)', () => {
+            const validData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                result: null
+            };
+            expect(() => validateInterviewCreateData(validData)).not.toThrow();
+        });
+    });
+
+    describe('Unexpected field rejection', () => {
+        it('should throw when an unexpected field is provided', () => {
+            const invalidData = {
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                unknownField: 'value'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('Unexpected field: unknownField');
+        });
+
+        it('should throw when id field is provided', () => {
+            const invalidData = {
+                id: 99,
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z'
+            };
+            expect(() => validateInterviewCreateData(invalidData)).toThrow('Unexpected field: id');
         });
     });
 });

--- a/backend/src/application/services/__tests__/interviewService.test.ts
+++ b/backend/src/application/services/__tests__/interviewService.test.ts
@@ -1,4 +1,4 @@
-import { updateInterview, deleteInterview } from '../interviewService';
+import { updateInterview, deleteInterview, createInterview } from '../interviewService';
 import { Candidate } from '../../../domain/models/Candidate';
 import { Application } from '../../../domain/models/Application';
 import { Position } from '../../../domain/models/Position';
@@ -546,7 +546,7 @@ describe('Interview Service', () => {
             });
         });
 
-        describe('Database error handling', () => {
+        describe('Database error handling for deleteInterview', () => {
             it('should throw error when database deletion fails', async () => {
                 const candidateId = 1;
                 const interviewId = 2;
@@ -573,6 +573,173 @@ describe('Interview Service', () => {
                 (Interview.delete as jest.Mock).mockRejectedValue(new Error('Database error'));
 
                 await expect(deleteInterview(candidateId, interviewId, deletionData)).rejects.toThrow('Database error');
+            });
+        });
+    });
+
+    describe('createInterview', () => {
+        const validInterviewData = {
+            applicationId: 1,
+            interviewStepId: 2,
+            employeeId: 3,
+            interviewDate: '2026-06-20T10:00:00Z',
+            result: 'Pending',
+            score: 4,
+            notes: 'Strong candidate'
+        };
+
+        const mockCandidate = { id: 1, firstName: 'John', lastName: 'Doe' };
+        const mockApplication = { id: 1, candidateId: 1, positionId: 10 };
+        const mockPosition = { id: 10, interviewFlowId: 5 };
+        const mockInterviewStep = { id: 2, interviewFlowId: 5 };
+        const mockEmployee = { id: 3, isActive: true };
+        const mockCreatedInterview = {
+            id: 99,
+            applicationId: 1,
+            interviewStepId: 2,
+            employeeId: 3,
+            interviewDate: new Date('2026-06-20T10:00:00Z'),
+            result: 'Pending',
+            score: 4,
+            notes: 'Strong candidate'
+        };
+
+        describe('Successful creation', () => {
+            it('should create an interview with all fields', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(mockApplication);
+                (Position.findOne as jest.Mock).mockResolvedValue(mockPosition);
+                (InterviewStep.findOne as jest.Mock).mockResolvedValue(mockInterviewStep);
+                (Employee.findOne as jest.Mock).mockResolvedValue(mockEmployee);
+
+                const mockInterviewInstance = {
+                    ...mockCreatedInterview,
+                    save: jest.fn().mockResolvedValue(mockCreatedInterview)
+                };
+                (Interview as unknown as jest.Mock).mockImplementation(() => mockInterviewInstance);
+
+                const result = await createInterview(1, validInterviewData);
+
+                expect(Candidate.findOne).toHaveBeenCalledWith(1);
+                expect(Application.findOne).toHaveBeenCalledWith(1);
+                expect(Position.findOne).toHaveBeenCalledWith(10);
+                expect(InterviewStep.findOne).toHaveBeenCalledWith(2);
+                expect(Employee.findOne).toHaveBeenCalledWith(3);
+                expect(mockInterviewInstance.save).toHaveBeenCalled();
+                expect(result.id).toBe(99);
+            });
+
+            it('should create an interview with minimal fields (result defaults to Pending)', async () => {
+                const minimalData = {
+                    applicationId: 1,
+                    interviewStepId: 2,
+                    employeeId: 3,
+                    interviewDate: '2026-06-20T10:00:00Z'
+                    // result omitted
+                };
+
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(mockApplication);
+                (Position.findOne as jest.Mock).mockResolvedValue(mockPosition);
+                (InterviewStep.findOne as jest.Mock).mockResolvedValue(mockInterviewStep);
+                (Employee.findOne as jest.Mock).mockResolvedValue(mockEmployee);
+
+                const mockInterviewInstance = {
+                    ...mockCreatedInterview,
+                    result: 'Pending',
+                    save: jest.fn().mockResolvedValue({ ...mockCreatedInterview, result: 'Pending' })
+                };
+                (Interview as unknown as jest.Mock).mockImplementation((data) => {
+                    expect(data.result).toBe('Pending');
+                    return mockInterviewInstance;
+                });
+
+                const result = await createInterview(1, minimalData);
+
+                expect(result.result).toBe('Pending');
+            });
+        });
+
+        describe('Candidate not found', () => {
+            it('should throw error when candidate does not exist', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(null);
+
+                await expect(createInterview(999, validInterviewData)).rejects.toThrow('not found');
+            });
+        });
+
+        describe('Application not found', () => {
+            it('should throw error when application does not exist', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(null);
+
+                await expect(createInterview(1, validInterviewData)).rejects.toThrow('not found');
+            });
+
+            it('should throw error when application does not belong to candidate', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue({ ...mockApplication, candidateId: 999 });
+
+                await expect(createInterview(1, validInterviewData)).rejects.toThrow();
+            });
+        });
+
+        describe('Interview step validation', () => {
+            it('should throw error when interview step does not exist', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(mockApplication);
+                (Position.findOne as jest.Mock).mockResolvedValue(mockPosition);
+                (InterviewStep.findOne as jest.Mock).mockResolvedValue(null);
+
+                await expect(createInterview(1, validInterviewData)).rejects.toThrow('not found');
+            });
+
+            it('should throw error when interview step does not belong to position interview flow', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(mockApplication);
+                (Position.findOne as jest.Mock).mockResolvedValue(mockPosition);
+                (InterviewStep.findOne as jest.Mock).mockResolvedValue({ id: 2, interviewFlowId: 99 }); // different flow
+
+                await expect(createInterview(1, validInterviewData)).rejects.toThrow('does not belong to the position\'s interview flow');
+            });
+        });
+
+        describe('Employee validation', () => {
+            it('should throw error when employee does not exist', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(mockApplication);
+                (Position.findOne as jest.Mock).mockResolvedValue(mockPosition);
+                (InterviewStep.findOne as jest.Mock).mockResolvedValue(mockInterviewStep);
+                (Employee.findOne as jest.Mock).mockResolvedValue(null);
+
+                await expect(createInterview(1, validInterviewData)).rejects.toThrow('not found');
+            });
+
+            it('should throw error when employee is not active', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(mockApplication);
+                (Position.findOne as jest.Mock).mockResolvedValue(mockPosition);
+                (InterviewStep.findOne as jest.Mock).mockResolvedValue(mockInterviewStep);
+                (Employee.findOne as jest.Mock).mockResolvedValue({ id: 3, isActive: false });
+
+                await expect(createInterview(1, validInterviewData)).rejects.toThrow('is not active');
+            });
+        });
+
+        describe('Database error handling', () => {
+            it('should propagate database errors on save', async () => {
+                (Candidate.findOne as jest.Mock).mockResolvedValue(mockCandidate);
+                (Application.findOne as jest.Mock).mockResolvedValue(mockApplication);
+                (Position.findOne as jest.Mock).mockResolvedValue(mockPosition);
+                (InterviewStep.findOne as jest.Mock).mockResolvedValue(mockInterviewStep);
+                (Employee.findOne as jest.Mock).mockResolvedValue(mockEmployee);
+
+                const mockInterviewInstance = {
+                    save: jest.fn().mockRejectedValue(new Error('Database connection failed'))
+                };
+                (Interview as unknown as jest.Mock).mockImplementation(() => mockInterviewInstance);
+
+                await expect(createInterview(1, validInterviewData)).rejects.toThrow('Database connection failed');
             });
         });
     });

--- a/backend/src/application/services/interviewService.ts
+++ b/backend/src/application/services/interviewService.ts
@@ -88,6 +88,76 @@ export const updateInterview = async (candidateId: number, interviewId: number, 
 };
 
 /**
+ * Creates a new interview for a candidate's application
+ * @param candidateId - The ID of the candidate (from URL path)
+ * @param interviewData - The interview data to create
+ * @returns The created interview
+ * @throws Error if validation fails or resources are not found
+ */
+export const createInterview = async (candidateId: number, interviewData: any): Promise<Interview> => {
+    // Validate candidate exists
+    const candidate = await Candidate.findOne(candidateId);
+    if (!candidate) {
+        throw new Error('Candidate not found');
+    }
+
+    // Validate application exists and belongs to candidate
+    const application = await Application.findOne(interviewData.applicationId);
+    if (!application) {
+        throw new Error('Application not found');
+    }
+    if (application.candidateId !== candidateId) {
+        throw new Error('Application does not belong to the specified candidate');
+    }
+
+    // Validate position for interview step flow check
+    const position = await Position.findOne(application.positionId);
+    if (!position) {
+        throw new Error('Position not found');
+    }
+
+    // Validate interview step exists and belongs to position's flow
+    const interviewStep = await InterviewStep.findOne(interviewData.interviewStepId);
+    if (!interviewStep) {
+        throw new Error('Interview step not found');
+    }
+    if (interviewStep.interviewFlowId !== position.interviewFlowId) {
+        throw new Error('Interview step does not belong to the position\'s interview flow');
+    }
+
+    // Validate employee exists and is active
+    const employee = await Employee.findOne(interviewData.employeeId);
+    if (!employee) {
+        throw new Error('Employee not found');
+    }
+    if (!employee.isActive) {
+        throw new Error('Employee is not active');
+    }
+
+    // Default result to Pending when omitted
+    const result = interviewData.result ?? 'Pending';
+
+    // Construct Interview without id (triggers insert in save())
+    const newInterview = new Interview({
+        applicationId: interviewData.applicationId,
+        interviewStepId: interviewData.interviewStepId,
+        employeeId: interviewData.employeeId,
+        interviewDate: interviewData.interviewDate,
+        result,
+        score: interviewData.score,
+        notes: interviewData.notes,
+    });
+
+    // Save (insert path since id is absent)
+    try {
+        const savedInterview = await newInterview.save();
+        return new Interview(savedInterview);
+    } catch (error: any) {
+        throw new Error(error.message || 'Failed to create interview');
+    }
+};
+
+/**
  * Deletes an interview for a candidate
  * @param candidateId - The ID of the candidate (from URL path)
  * @param interviewId - The ID of the interview to delete

--- a/backend/src/application/validator.ts
+++ b/backend/src/application/validator.ts
@@ -247,6 +247,63 @@ export const validateInterviewDeletion = (candidateId: any, interviewId: any, de
     }
 };
 
+const INTERVIEW_CREATE_ALLOWED_FIELDS = ['applicationId', 'interviewStepId', 'employeeId', 'interviewDate', 'result', 'score', 'notes'];
+
+export const validateInterviewCreateData = (data: any): void => {
+    if (data === null || data === undefined || typeof data !== 'object' || Array.isArray(data)) {
+        throw new Error('Request body is required');
+    }
+
+    for (const key of Object.keys(data)) {
+        if (!INTERVIEW_CREATE_ALLOWED_FIELDS.includes(key)) {
+            throw new Error(`Unexpected field: ${key}`);
+        }
+    }
+
+    if (data.applicationId === undefined || data.applicationId === null) {
+        throw new Error('applicationId is required');
+    }
+    if (typeof data.applicationId !== 'number' || !Number.isInteger(data.applicationId) || data.applicationId <= 0) {
+        throw new Error('applicationId must be a positive integer');
+    }
+
+    if (data.interviewStepId === undefined || data.interviewStepId === null) {
+        throw new Error('interviewStepId is required');
+    }
+    if (typeof data.interviewStepId !== 'number' || !Number.isInteger(data.interviewStepId) || data.interviewStepId <= 0) {
+        throw new Error('interviewStepId must be a positive integer');
+    }
+
+    if (data.employeeId === undefined || data.employeeId === null) {
+        throw new Error('employeeId is required');
+    }
+    if (typeof data.employeeId !== 'number' || !Number.isInteger(data.employeeId) || data.employeeId <= 0) {
+        throw new Error('employeeId must be a positive integer');
+    }
+
+    if (data.interviewDate === undefined || data.interviewDate === null) {
+        throw new Error('interviewDate is required');
+    }
+    if (typeof data.interviewDate !== 'string') throw new Error('interviewDate must be a string');
+    if (!isValidISO8601DateTime(data.interviewDate)) throw new Error('interviewDate must be valid ISO 8601');
+
+    if (data.score !== undefined && data.score !== null) {
+        if (typeof data.score !== 'number' || !Number.isInteger(data.score) || data.score < 0 || data.score > 5) {
+            throw new Error('Score must be between 0 and 5');
+        }
+    }
+
+    if (data.notes !== undefined && data.notes !== null) {
+        if (typeof data.notes !== 'string') throw new Error('notes must be a string');
+        if (data.notes.length > 1000) throw new Error('Notes must not exceed 1000 characters');
+    }
+
+    if (data.result !== undefined && data.result !== null) {
+        if (typeof data.result !== 'string') throw new Error('result must be a string');
+        if (!INTERVIEW_RESULT_VALUES.includes(data.result)) throw new Error('Invalid result value');
+    }
+};
+
 export const validateCandidatePositionDeletion = (positionId: any, candidateId: any): void => {
     if (typeof positionId !== 'number' || !Number.isInteger(positionId) || positionId <= 0) {
         throw new Error('positionId must be a positive integer');

--- a/backend/src/presentation/controllers/__tests__/interviewController.test.ts
+++ b/backend/src/presentation/controllers/__tests__/interviewController.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
-import { updateInterviewController, deleteInterviewController } from '../interviewController';
-import { updateInterview, deleteInterview } from '../../../application/services/interviewService';
-import { validateInterviewUpdateData, validateInterviewDeletion } from '../../../application/validator';
+import { updateInterviewController, deleteInterviewController, createInterviewController } from '../interviewController';
+import { updateInterview, deleteInterview, createInterview } from '../../../application/services/interviewService';
+import { validateInterviewUpdateData, validateInterviewDeletion, validateInterviewCreateData } from '../../../application/validator';
 
 // Mock services and validator
 jest.mock('../../../application/services/interviewService');
@@ -9,8 +9,10 @@ jest.mock('../../../application/validator');
 
 const mockUpdateInterview = updateInterview as jest.MockedFunction<typeof updateInterview>;
 const mockDeleteInterview = deleteInterview as jest.MockedFunction<typeof deleteInterview>;
+const mockCreateInterview = createInterview as jest.MockedFunction<typeof createInterview>;
 const mockValidateInterviewUpdateData = validateInterviewUpdateData as jest.MockedFunction<typeof validateInterviewUpdateData>;
 const mockValidateInterviewDeletion = validateInterviewDeletion as jest.MockedFunction<typeof validateInterviewDeletion>;
+const mockValidateInterviewCreateData = validateInterviewCreateData as jest.MockedFunction<typeof validateInterviewCreateData>;
 
 describe('Interview Controller', () => {
     let mockRequest: Partial<Request>;
@@ -474,6 +476,236 @@ describe('Interview Controller', () => {
                 mockDeleteInterview.mockRejectedValue(new Error('Database connection failed'));
 
                 await deleteInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(500);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: expect.any(String)
+                    })
+                );
+            });
+        });
+    });
+
+    describe('createInterviewController', () => {
+        const validCreateBody = {
+            applicationId: 1,
+            interviewStepId: 2,
+            employeeId: 3,
+            interviewDate: '2026-06-20T10:00:00Z',
+            result: 'Pending',
+            score: 4,
+            notes: 'Strong candidate'
+        };
+
+        const mockCreatedInterview = {
+            id: 99,
+            applicationId: 1,
+            interviewStepId: 2,
+            employeeId: 3,
+            interviewDate: new Date('2026-06-20T10:00:00Z'),
+            result: 'Pending',
+            score: 4,
+            notes: 'Strong candidate'
+        };
+
+        describe('Successful creation', () => {
+            it('should return 201 with created interview on success', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockResolvedValue(mockCreatedInterview as any);
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockValidateInterviewCreateData).toHaveBeenCalledWith(validCreateBody);
+                expect(mockCreateInterview).toHaveBeenCalledWith(1, validCreateBody);
+                expect(mockStatus).toHaveBeenCalledWith(201);
+                expect(mockJson).toHaveBeenCalledWith(mockCreatedInterview);
+            });
+        });
+
+        describe('Invalid candidateId format', () => {
+            it('should return 400 when candidateId is not a valid number', async () => {
+                mockRequest.params = { candidateId: 'invalid' };
+                mockRequest.body = validCreateBody;
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(400);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: expect.any(String)
+                    })
+                );
+                expect(mockCreateInterview).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('Validator errors', () => {
+            it('should return 400 when validator throws', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = { applicationId: 1 }; // Missing required fields
+
+                mockValidateInterviewCreateData.mockImplementation(() => {
+                    throw new Error('interviewStepId is required');
+                });
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(400);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: 'interviewStepId is required'
+                    })
+                );
+                expect(mockCreateInterview).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('Not found errors', () => {
+            it('should return 404 when candidate not found', async () => {
+                mockRequest.params = { candidateId: '999' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Candidate not found'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(404);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: 'Candidate not found'
+                    })
+                );
+            });
+
+            it('should return 404 when application not found', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = { ...validCreateBody, applicationId: 999 };
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Application not found'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(404);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: 'Application not found'
+                    })
+                );
+            });
+
+            it('should return 404 when application does not belong to candidate', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Application does not belong to the specified candidate'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(404);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: 'Application does not belong to the specified candidate'
+                    })
+                );
+            });
+
+            it('should return 404 when interview step not found', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Interview step not found'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(404);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: 'Interview step not found'
+                    })
+                );
+            });
+
+            it('should return 404 when employee not found', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Employee not found'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(404);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: 'Employee not found'
+                    })
+                );
+            });
+        });
+
+        describe('Business rule errors (400)', () => {
+            it('should return 400 when interview step does not belong to position flow', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Interview step does not belong to the position\'s interview flow'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(400);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: expect.stringContaining('does not belong to the position\'s interview flow')
+                    })
+                );
+            });
+
+            it('should return 400 when employee is not active', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Employee is not active'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
+
+                expect(mockStatus).toHaveBeenCalledWith(400);
+                expect(mockJson).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.any(String),
+                        error: 'Employee is not active'
+                    })
+                );
+            });
+        });
+
+        describe('Server errors', () => {
+            it('should return 500 when service throws unexpected error', async () => {
+                mockRequest.params = { candidateId: '1' };
+                mockRequest.body = validCreateBody;
+
+                mockValidateInterviewCreateData.mockImplementation(() => {});
+                mockCreateInterview.mockRejectedValue(new Error('Database connection failed'));
+
+                await createInterviewController(mockRequest as Request, mockResponse as Response, jest.fn());
 
                 expect(mockStatus).toHaveBeenCalledWith(500);
                 expect(mockJson).toHaveBeenCalledWith(

--- a/backend/src/presentation/controllers/interviewController.ts
+++ b/backend/src/presentation/controllers/interviewController.ts
@@ -1,6 +1,78 @@
 import { Request, Response, NextFunction } from 'express';
-import { updateInterview, deleteInterview } from '../../application/services/interviewService';
-import { validateInterviewUpdateData, validateInterviewDeletion } from '../../application/validator';
+import { updateInterview, deleteInterview, createInterview } from '../../application/services/interviewService';
+import { validateInterviewUpdateData, validateInterviewDeletion, validateInterviewCreateData } from '../../application/validator';
+
+/**
+ * @route POST /candidates/:candidateId/interviews
+ * @description Creates a new interview for a candidate's application
+ * @access Public
+ */
+export const createInterviewController = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        // Extract candidateId from URL params
+        const candidateId = parseInt(req.params.candidateId);
+
+        // Validate candidateId format
+        if (isNaN(candidateId)) {
+            return res.status(400).json({
+                message: 'Validation error',
+                error: 'Invalid candidate ID format'
+            });
+        }
+
+        // Extract interview data from request body
+        const interviewData = req.body;
+
+        // Validate interview create data
+        try {
+            validateInterviewCreateData(interviewData);
+        } catch (validationError: any) {
+            return res.status(400).json({
+                message: 'Validation error',
+                error: validationError.message
+            });
+        }
+
+        // Create interview
+        const createdInterview = await createInterview(candidateId, interviewData);
+
+        // Return 201 Created with created interview data
+        return res.status(201).json(createdInterview);
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            // Handle business rule validation errors (400) - check these BEFORE 404 checks
+            // Important: "does not belong to the position's interview flow" contains "does not belong"
+            // so must be checked before the general "does not belong" → 404 branch
+            if (error.message.includes('does not belong to the position\'s interview flow') ||
+                error.message.includes('is not active')) {
+                return res.status(400).json({
+                    message: 'Validation error',
+                    error: error.message
+                });
+            }
+
+            // Handle specific error types (404)
+            if (error.message.includes('not found') || error.message.includes('does not belong')) {
+                return res.status(404).json({
+                    message: 'Resource not found',
+                    error: error.message
+                });
+            }
+
+            // Handle other errors as 500
+            return res.status(500).json({
+                message: 'Internal server error',
+                error: 'An unexpected error occurred'
+            });
+        }
+
+        // Handle unknown errors
+        return res.status(500).json({
+            message: 'Internal server error',
+            error: 'An unexpected error occurred'
+        });
+    }
+};
 
 /**
  * @route PATCH /candidates/:candidateId/interviews/:interviewId

--- a/backend/src/routes/candidateRoutes.integration.test.ts
+++ b/backend/src/routes/candidateRoutes.integration.test.ts
@@ -1,0 +1,118 @@
+import express from 'express';
+import request from 'supertest';
+import candidateRoutes from './candidateRoutes';
+import { createInterview } from '../application/services/interviewService';
+import { validateInterviewCreateData } from '../application/validator';
+
+jest.mock('../application/services/interviewService', () => ({
+    createInterview: jest.fn(),
+    updateInterview: jest.fn(),
+    deleteInterview: jest.fn(),
+}));
+
+jest.mock('../application/validator', () => ({
+    validateInterviewCreateData: jest.fn(),
+    validateInterviewUpdateData: jest.fn(),
+    validateInterviewDeletion: jest.fn(),
+}));
+
+// Mock candidate controller functions
+jest.mock('../presentation/controllers/candidateController', () => ({
+    addCandidate: jest.fn(),
+    getCandidateById: jest.fn((req: any, res: any) => res.status(200).json({})),
+    updateCandidateStageController: jest.fn((req: any, res: any) => res.status(200).json({})),
+    getAllCandidatesController: jest.fn((req: any, res: any) => res.status(200).json([])),
+}));
+
+describe('candidateRoutes - POST /:candidateId/interviews', () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/candidates', candidateRoutes);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns 201 with created interview on valid request', async () => {
+        const mockCreatedInterview = {
+            id: 99,
+            applicationId: 1,
+            interviewStepId: 2,
+            employeeId: 3,
+            interviewDate: new Date('2026-06-20T10:00:00Z'),
+            result: 'Pending',
+            score: 4,
+            notes: 'Strong candidate'
+        };
+
+        (validateInterviewCreateData as jest.Mock).mockImplementation(() => {});
+        (createInterview as jest.Mock).mockResolvedValue(mockCreatedInterview);
+
+        const response = await request(app)
+            .post('/candidates/1/interviews')
+            .send({
+                applicationId: 1,
+                interviewStepId: 2,
+                employeeId: 3,
+                interviewDate: '2026-06-20T10:00:00Z',
+                result: 'Pending',
+                score: 4,
+                notes: 'Strong candidate'
+            });
+
+        expect(response.status).toBe(201);
+        expect(response.body).toMatchObject({ id: 99, applicationId: 1 });
+        expect(validateInterviewCreateData).toHaveBeenCalled();
+        expect(createInterview).toHaveBeenCalledWith(1, expect.objectContaining({ applicationId: 1 }));
+    });
+
+    it('returns 400 for invalid candidateId format', async () => {
+        const response = await request(app)
+            .post('/candidates/abc/interviews')
+            .send({ applicationId: 1, interviewStepId: 2, employeeId: 3, interviewDate: '2026-06-20T10:00:00Z' });
+
+        expect(response.status).toBe(400);
+        expect(response.body).toMatchObject({ message: expect.any(String), error: expect.any(String) });
+        expect(createInterview).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when validator throws', async () => {
+        (validateInterviewCreateData as jest.Mock).mockImplementation(() => {
+            throw new Error('applicationId is required');
+        });
+
+        const response = await request(app)
+            .post('/candidates/1/interviews')
+            .send({});
+
+        expect(response.status).toBe(400);
+        expect(response.body).toMatchObject({ message: expect.any(String), error: 'applicationId is required' });
+        expect(createInterview).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when candidate not found', async () => {
+        (validateInterviewCreateData as jest.Mock).mockImplementation(() => {});
+        (createInterview as jest.Mock).mockRejectedValue(new Error('Candidate not found'));
+
+        const response = await request(app)
+            .post('/candidates/999/interviews')
+            .send({ applicationId: 1, interviewStepId: 2, employeeId: 3, interviewDate: '2026-06-20T10:00:00Z' });
+
+        expect(response.status).toBe(404);
+        expect(response.body).toMatchObject({ message: expect.any(String), error: 'Candidate not found' });
+    });
+
+    it('returns 400 when interview step does not belong to flow', async () => {
+        (validateInterviewCreateData as jest.Mock).mockImplementation(() => {});
+        (createInterview as jest.Mock).mockRejectedValue(
+            new Error('Interview step does not belong to the position\'s interview flow')
+        );
+
+        const response = await request(app)
+            .post('/candidates/1/interviews')
+            .send({ applicationId: 1, interviewStepId: 99, employeeId: 3, interviewDate: '2026-06-20T10:00:00Z' });
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toContain('does not belong to the position\'s interview flow');
+    });
+});

--- a/backend/src/routes/candidateRoutes.ts
+++ b/backend/src/routes/candidateRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { addCandidate, getCandidateById, updateCandidateStageController, getAllCandidatesController } from '../presentation/controllers/candidateController';
-import { updateInterviewController, deleteInterviewController } from '../presentation/controllers/interviewController';
+import { updateInterviewController, deleteInterviewController, createInterviewController } from '../presentation/controllers/interviewController';
 
 const router = Router();
 
@@ -21,6 +21,7 @@ router.post('/', async (req, res) => {
 });
 
 // Interview routes - must be before /:id to avoid route conflicts
+router.post('/:candidateId/interviews', createInterviewController);
 router.patch('/:candidateId/interviews/:interviewId', updateInterviewController);
 router.delete('/:candidateId/interviews/:interviewId', deleteInterviewController);
 

--- a/docs/api-spec.yml
+++ b/docs/api-spec.yml
@@ -201,6 +201,68 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /candidates/{candidateId}/interviews:
+    post:
+      summary: Create a new interview for a candidate
+      description: Creates a new interview for one of the candidate's applications. Validates that the application belongs to the candidate, the interview step belongs to the position's interview flow, and the employee is active.
+      tags:
+        - Candidates
+      parameters:
+        - in: path
+          name: candidateId
+          required: true
+          schema:
+            type: integer
+          description: ID of the candidate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateInterviewRequest'
+            example:
+              applicationId: 1
+              interviewStepId: 2
+              employeeId: 3
+              interviewDate: "2026-06-20T10:00:00Z"
+              result: "Pending"
+              score: 4
+              notes: "Strong technical candidate"
+      responses:
+        '201':
+          description: Interview created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterviewResponse'
+              example:
+                id: 99
+                applicationId: 1
+                interviewStepId: 2
+                employeeId: 3
+                interviewDate: "2026-06-20T10:00:00.000Z"
+                result: "Pending"
+                score: 4
+                notes: "Strong technical candidate"
+        '400':
+          description: Validation error or business rule violation (step not in flow, employee not active)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Candidate, application, interview step, or employee not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /candidates/{candidateId}/interviews/{interviewId}:
     patch:
       summary: Update an existing interview
@@ -1433,6 +1495,48 @@ components:
         notes:
           type: string
           nullable: true
+
+    CreateInterviewRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - applicationId
+        - interviewStepId
+        - employeeId
+        - interviewDate
+      properties:
+        applicationId:
+          type: integer
+          minimum: 1
+          description: ID of the application (must belong to the path candidateId)
+        interviewStepId:
+          type: integer
+          minimum: 1
+          description: ID of the interview step (must belong to the application's position's interview flow)
+        employeeId:
+          type: integer
+          minimum: 1
+          description: ID of the interviewing employee (must be active)
+        interviewDate:
+          type: string
+          format: date-time
+          description: ISO 8601 date-time of the interview
+        result:
+          type: string
+          nullable: true
+          enum: [Pending, Passed, Failed]
+          description: Interview result (defaults to Pending when omitted)
+        score:
+          type: integer
+          nullable: true
+          minimum: 0
+          maximum: 5
+          description: Interview score (0-5 inclusive or null)
+        notes:
+          type: string
+          maxLength: 1000
+          nullable: true
+          description: Optional notes (max 1000 characters)
 
     UpdateInterviewRequest:
       type: object

--- a/frontend/src/components/CandidateDetails.createInterview.test.js
+++ b/frontend/src/components/CandidateDetails.createInterview.test.js
@@ -1,0 +1,346 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import CandidateDetails from './CandidateDetails';
+import { createInterview } from '../services/interviewService';
+
+jest.mock('react-bootstrap', () => {
+  const ReactLib = require('react');
+  const Button = ({ children, ...props }) => <button {...props}>{children}</button>;
+  const Alert = ({ children, variant, ...props }) => <div data-variant={variant} {...props}>{children}</div>;
+  const Modal = ({ show, children }) => (show ? <div role="dialog">{children}</div> : null);
+  Modal.Header = ({ children }) => <div>{children}</div>;
+  Modal.Title = ({ children }) => <div>{children}</div>;
+  Modal.Body = ({ children }) => <div>{children}</div>;
+  Modal.Footer = ({ children }) => <div>{children}</div>;
+  const Offcanvas = ({ show, children }) => (show ? <div role="dialog">{children}</div> : null);
+  Offcanvas.Header = ({ children }) => <div>{children}</div>;
+  Offcanvas.Title = ({ children }) => <div>{children}</div>;
+  Offcanvas.Body = ({ children }) => <div>{children}</div>;
+  const Form = ({ children, ...props }) => <form {...props}>{children}</form>;
+  Form.Group = ({ children }) => <div>{children}</div>;
+  Form.Label = ({ children }) => <label>{children}</label>;
+  Form.Text = ({ children }) => <small>{children}</small>;
+  Form.Control = ({ as, children, isInvalid, ...props }) =>
+    as === 'textarea' ? (
+      <textarea aria-invalid={isInvalid || undefined} {...props}>{children}</textarea>
+    ) : (
+      <input aria-invalid={isInvalid || undefined} {...props} />
+    );
+  Form.Control.Feedback = ({ children }) => <div>{children}</div>;
+  Form.Select = ({ children, isInvalid, ...props }) => (
+    <select aria-invalid={isInvalid || undefined} {...props}>{children}</select>
+  );
+  return {
+    Button,
+    Alert,
+    Modal,
+    Offcanvas,
+    Form,
+  };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, params) => {
+      if (params && params.max) return `${key}:${params.max}`;
+      if (params && params.star) return `${key}:${params.star}`;
+      return key;
+    },
+  }),
+}));
+
+jest.mock('../services/interviewService', () => ({
+  createInterview: jest.fn(),
+  updateInterview: jest.fn(),
+  deleteInterview: jest.fn(),
+}));
+
+jest.mock('../services/positionService', () => ({
+  positionService: {
+    removeCandidateFromPosition: jest.fn(),
+  },
+}));
+
+const candidateProp = { id: 5 };
+
+const interviewFlowSteps = [
+  { id: 10, name: 'HR Screen' },
+  { id: 11, name: 'Technical' },
+];
+
+const candidateDetailsPayload = {
+  id: 5,
+  firstName: 'Test',
+  lastName: 'User',
+  email: 'test@example.com',
+  phone: '000000000',
+  address: 'Test Street',
+  educations: [],
+  workExperiences: [],
+  resumes: [],
+  applications: [
+    {
+      id: 20,
+      applicationDate: '2026-01-01T00:00:00.000Z',
+      position: { id: 7, title: 'Frontend Engineer' },
+      interviews: [],
+    },
+    {
+      id: 21,
+      applicationDate: '2026-02-01T00:00:00.000Z',
+      position: { id: 8, title: 'Backend Engineer' },
+      interviews: [],
+    },
+  ],
+};
+
+const employeesPayload = [
+  { id: 1, name: 'Alice', email: 'alice@company.com' },
+  { id: 2, name: 'Bob', email: 'bob@company.com' },
+];
+
+const createFetchResponse = (payload) =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(payload),
+  });
+
+describe('CandidateDetails create interview flow', () => {
+  beforeAll(() => {
+    const matchMediaMock = jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: matchMediaMock });
+    global.matchMedia = matchMediaMock;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn((url) => {
+      if (url.includes('/employees')) return createFetchResponse(employeesPayload);
+      if (url.includes('/interviewFlow')) {
+        return createFetchResponse({
+          interviewFlow: { interviewFlow: { interviewSteps: interviewFlowSteps } },
+        });
+      }
+      return createFetchResponse(candidateDetailsPayload);
+    });
+  });
+
+  it('shows "Add interview" action for each application', async () => {
+    render(<CandidateDetails candidate={candidateProp} onClose={jest.fn()} />);
+
+    const addButtons = await screen.findAllByLabelText('interviews.addInterview');
+    expect(addButtons).toHaveLength(2);
+  });
+
+  it('clicking "Add interview" opens the create modal with correct title and empty fields', async () => {
+    render(<CandidateDetails candidate={candidateProp} onClose={jest.fn()} />);
+
+    const addButtons = await screen.findAllByLabelText('interviews.addInterview');
+    fireEvent.click(addButtons[0]);
+
+    expect(await screen.findByText('interviews.createTitle')).not.toBeNull();
+    // The application context is shown as a read-only field
+    expect(screen.getByDisplayValue('Frontend Engineer')).not.toBeNull();
+    // Date field should be empty
+    const dateInput = screen.getByLabelText('interviews.dateTime');
+    expect(dateInput.value).toBe('');
+  });
+
+  it('shows validation errors when required fields are missing', async () => {
+    render(<CandidateDetails candidate={candidateProp} onClose={jest.fn()} />);
+
+    const addButtons = await screen.findAllByLabelText('interviews.addInterview');
+    fireEvent.click(addButtons[0]);
+
+    await screen.findByText('interviews.createTitle');
+
+    // Submit the form directly to trigger validation
+    await act(async () => {
+      const forms = document.querySelectorAll('form');
+      fireEvent.submit(forms[forms.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('validation.interviewDate.required')).not.toBeNull();
+      expect(screen.getByText('validation.interviewStep.required')).not.toBeNull();
+      expect(screen.getByText('validation.employee.required')).not.toBeNull();
+    });
+    // createInterview should not have been called
+    expect(createInterview).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when notes exceed max length', async () => {
+    render(<CandidateDetails candidate={candidateProp} onClose={jest.fn()} />);
+
+    const addButtons = await screen.findAllByLabelText('interviews.addInterview');
+    fireEvent.click(addButtons[0]);
+
+    await screen.findByText('interviews.createTitle');
+
+    // Fill required fields
+    await act(async () => {
+      fireEvent.change(document.querySelector('input[name="interviewDate"]'), {
+        target: { name: 'interviewDate', value: '2026-07-01T10:00' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.querySelector('select[name="interviewStepId"]'), {
+        target: { name: 'interviewStepId', value: '10' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(document.querySelector('select[name="employeeId"]'), {
+        target: { name: 'employeeId', value: '1' },
+      });
+    });
+
+    // Notes too long (1001 chars)
+    const longNotes = 'a'.repeat(1001);
+    await act(async () => {
+      fireEvent.change(document.querySelector('textarea[name="notes"]'), {
+        target: { name: 'notes', value: longNotes },
+      });
+    });
+
+    await act(async () => {
+      const forms = document.querySelectorAll('form');
+      fireEvent.submit(forms[forms.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('validation.notes.tooLong:1000')).not.toBeNull();
+    });
+    expect(createInterview).not.toHaveBeenCalled();
+  });
+
+  it('successful create appends the interview and shows success message', async () => {
+    const createdInterview = {
+      id: 99,
+      applicationId: 20,
+      interviewStepId: 10,
+      employeeId: 1,
+      interviewDate: '2026-07-01T10:00:00.000Z',
+      result: 'Pending',
+      score: null,
+      notes: null,
+      interviewStep: { id: 10, name: 'HR Screen' },
+    };
+    createInterview.mockResolvedValue(createdInterview);
+
+    render(<CandidateDetails candidate={candidateProp} onClose={jest.fn()} />);
+
+    const addButtons = await screen.findAllByLabelText('interviews.addInterview');
+
+    await act(async () => {
+      fireEvent.click(addButtons[0]);
+    });
+
+    await screen.findByText('interviews.createTitle');
+
+    await act(async () => {
+      const dateInput = document.querySelector('input[name="interviewDate"]');
+      fireEvent.change(dateInput, { target: { name: 'interviewDate', value: '2026-07-01T10:00' } });
+    });
+
+    await act(async () => {
+      const stepSelect = document.querySelector('select[name="interviewStepId"]');
+      fireEvent.change(stepSelect, { target: { name: 'interviewStepId', value: '10' } });
+    });
+
+    await act(async () => {
+      const employeeSelect = document.querySelector('select[name="employeeId"]');
+      fireEvent.change(employeeSelect, { target: { name: 'employeeId', value: '1' } });
+    });
+
+    // Submit the form and flush all async React state updates
+    await act(async () => {
+      const forms = document.querySelectorAll('form');
+      fireEvent.submit(forms[forms.length - 1]);
+    });
+
+    // Wait for createInterview to be called (it's async inside handleCreateSubmit)
+    await waitFor(() => {
+      expect(createInterview).toHaveBeenCalled();
+    });
+
+    // Confirm createInterview was called with correct args
+    expect(createInterview).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        applicationId: 20,
+        interviewStepId: 10,
+        employeeId: 1,
+      })
+    );
+
+    // Modal should close and success message should appear
+    await waitFor(() => expect(screen.queryByText('interviews.createTitle')).toBeNull(), { timeout: 3000 });
+    expect(await screen.findByText('interviews.createSuccess', {}, { timeout: 3000 })).not.toBeNull();
+  });
+
+  it('Cancel closes the modal without making an API call', async () => {
+    render(<CandidateDetails candidate={candidateProp} onClose={jest.fn()} />);
+
+    const addButtons = await screen.findAllByLabelText('interviews.addInterview');
+    fireEvent.click(addButtons[0]);
+
+    await screen.findByText('interviews.createTitle');
+
+    // Click the Cancel button (common.cancel key)
+    const cancelButtons = screen.getAllByText('common.cancel');
+    fireEvent.click(cancelButtons[cancelButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('interviews.createTitle')).toBeNull();
+    });
+    expect(createInterview).not.toHaveBeenCalled();
+  });
+
+  it('shows error message when API call fails', async () => {
+    createInterview.mockRejectedValue(new Error('Internal server error'));
+
+    render(<CandidateDetails candidate={candidateProp} onClose={jest.fn()} />);
+
+    const addButtons = await screen.findAllByLabelText('interviews.addInterview');
+    fireEvent.click(addButtons[0]);
+
+    await screen.findByText('interviews.createTitle');
+
+    await act(async () => {
+      const dateInput = document.querySelector('input[name="interviewDate"]');
+      fireEvent.change(dateInput, { target: { name: 'interviewDate', value: '2026-07-01T10:00' } });
+    });
+
+    await act(async () => {
+      const stepSelect = document.querySelector('select[name="interviewStepId"]');
+      fireEvent.change(stepSelect, { target: { name: 'interviewStepId', value: '10' } });
+    });
+
+    await act(async () => {
+      const employeeSelect = document.querySelector('select[name="employeeId"]');
+      fireEvent.change(employeeSelect, { target: { name: 'employeeId', value: '1' } });
+    });
+
+    await act(async () => {
+      const forms = document.querySelectorAll('form');
+      fireEvent.submit(forms[forms.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Internal server error')).not.toBeNull();
+      // Modal should remain open
+      expect(screen.getByText('interviews.createTitle')).not.toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/CandidateDetails.js
+++ b/frontend/src/components/CandidateDetails.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Offcanvas, Form, Button, Alert, Modal } from 'react-bootstrap';
-import { Pencil, Trash } from 'react-bootstrap-icons';
+import { Pencil, PlusCircle, Trash } from 'react-bootstrap-icons';
 import { useTranslation } from 'react-i18next';
-import { updateInterview, deleteInterview } from '../services/interviewService';
+import { createInterview, updateInterview, deleteInterview } from '../services/interviewService';
 import { positionService } from '../services/positionService';
 import './CandidateDetails.css';
 
@@ -18,6 +18,15 @@ const isInterviewDeletable = (interview) => {
 };
 
 const getInitialEditFormState = () => ({
+  interviewStepId: '',
+  employeeId: '',
+  interviewDate: '',
+  score: null,
+  notes: '',
+  result: 'Pending'
+});
+
+const getInitialCreateFormState = () => ({
   interviewStepId: '',
   employeeId: '',
   interviewDate: '',
@@ -58,6 +67,14 @@ const CandidateDetails = ({ candidate, onClose, onApplicationRemoved }) => {
   const [removeApplicationLoading, setRemoveApplicationLoading] = useState(false);
   const [removeApplicationError, setRemoveApplicationError] = useState(null);
 
+  const [creatingForApplication, setCreatingForApplication] = useState(null);
+  const [createInterviewData, setCreateInterviewData] = useState(getInitialCreateFormState());
+  const [createSteps, setCreateSteps] = useState([]);
+  const [createStepsLoading, setCreateStepsLoading] = useState(false);
+  const [createLoading, setCreateLoading] = useState(false);
+  const [createError, setCreateError] = useState(null);
+  const [createValidationErrors, setCreateValidationErrors] = useState({});
+
   useEffect(() => {
     if (candidate) {
       setError(null);
@@ -70,7 +87,7 @@ const CandidateDetails = ({ candidate, onClose, onApplicationRemoved }) => {
           setError(t('interviews.failedToLoad'));
         });
     }
-  }, [candidate, t]);
+  }, [candidate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!candidate) return;
@@ -106,20 +123,6 @@ const CandidateDetails = ({ candidate, onClose, onApplicationRemoved }) => {
         .then((data) => {
           const steps = data?.interviewFlow?.interviewFlow?.interviewSteps ?? [];
           const currentStep = interview.interviewStep;
-          // #region agent log
-          const stepIds = (steps || []).map((s) => (s == null ? 'null' : s.id));
-          fetch('http://127.0.0.1:7242/ingest/01a6f721-0594-4e0b-a031-946eb64c655e', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              location: 'CandidateDetails.js:openEditModal',
-              message: 'interviewFlow steps',
-              data: { currentStepIsNull: currentStep == null, stepIds },
-              timestamp: Date.now(),
-              hypothesisId: 'H4'
-            })
-          }).catch(() => {});
-          // #endregion
           const hasCurrent = currentStep?.id != null && steps.some((s) => Number(s.id) === Number(currentStep.id));
           const stepsToSet = hasCurrent || !currentStep?.id ? steps : [{ id: currentStep.id, name: currentStep.name }, ...steps];
           setEditSteps(stepsToSet);
@@ -159,6 +162,102 @@ const CandidateDetails = ({ candidate, onClose, onApplicationRemoved }) => {
     if (removeApplicationLoading) return;
     setRemoveApplicationModal(null);
     setRemoveApplicationError(null);
+  };
+
+  const openCreateModal = (application) => {
+    setCreatingForApplication(application);
+    setCreateInterviewData(getInitialCreateFormState());
+    setCreateError(null);
+    setCreateValidationErrors({});
+    setCreateSteps([]);
+    const positionId = application?.position?.id;
+    if (positionId) {
+      setCreateStepsLoading(true);
+      fetch(`${API_BASE_URL}/positions/${positionId}/interviewFlow`)
+        .then((res) => res.json())
+        .then((data) => {
+          const steps = data?.interviewFlow?.interviewFlow?.interviewSteps ?? [];
+          setCreateSteps(steps);
+        })
+        .catch(() => setCreateSteps([]))
+        .finally(() => setCreateStepsLoading(false));
+    }
+  };
+
+  const closeCreateModal = () => {
+    setCreatingForApplication(null);
+    setCreateInterviewData(getInitialCreateFormState());
+    setCreateError(null);
+    setCreateValidationErrors({});
+    setCreateSteps([]);
+  };
+
+  const handleCreateInputChange = (e) => {
+    const { name, value } = e.target;
+    setCreateInterviewData((prev) => ({ ...prev, [name]: value }));
+    if (createValidationErrors[name]) setCreateValidationErrors((prev) => ({ ...prev, [name]: null }));
+  };
+
+  const handleCreateScoreChange = (value) => {
+    const newScore = createInterviewData.score === value ? null : value;
+    setCreateInterviewData((prev) => ({ ...prev, score: newScore }));
+  };
+
+  const validateCreateForm = () => {
+    const errors = {};
+    if (!createInterviewData.interviewStepId) errors.interviewStepId = t('validation.interviewStep.required');
+    if (!createInterviewData.employeeId) errors.employeeId = t('validation.employee.required');
+    if (!createInterviewData.interviewDate) errors.interviewDate = t('validation.interviewDate.required');
+    if (createInterviewData.notes && createInterviewData.notes.length > NOTES_MAX_LENGTH) {
+      errors.notes = t('validation.notes.tooLong', { max: NOTES_MAX_LENGTH });
+    }
+    setCreateValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleCreateSubmit = async (e) => {
+    e.preventDefault();
+    setCreateError(null);
+    if (!validateCreateForm() || !creatingForApplication || !candidate) return;
+
+    const interviewDateISO = createInterviewData.interviewDate
+      ? new Date(createInterviewData.interviewDate).toISOString()
+      : undefined;
+
+    const payload = {
+      applicationId: creatingForApplication.id,
+      interviewStepId: Number(createInterviewData.interviewStepId),
+      employeeId: Number(createInterviewData.employeeId),
+      interviewDate: interviewDateISO,
+      result: createInterviewData.result || 'Pending',
+      score: createInterviewData.score != null && createInterviewData.score !== '' ? Number(createInterviewData.score) : null,
+      notes: createInterviewData.notes && createInterviewData.notes.trim() ? createInterviewData.notes.trim() : null
+    };
+
+    setCreateLoading(true);
+    try {
+      const created = await createInterview(candidate.id, payload);
+      setSuccessMessage(t('interviews.createSuccess'));
+      setCandidateDetails((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          applications: prev.applications.map((app) =>
+            app.id === creatingForApplication.id
+              ? {
+                  ...app,
+                  interviews: [...(app.interviews || []), created]
+                }
+              : app
+          )
+        };
+      });
+      closeCreateModal();
+    } catch (err) {
+      setCreateError(err.message || t('interviews.failedToCreate'));
+    } finally {
+      setCreateLoading(false);
+    }
   };
 
   const handleRemoveApplicationConfirm = async () => {
@@ -381,7 +480,18 @@ const CandidateDetails = ({ candidate, onClose, onApplicationRemoved }) => {
                     </Button>
                   </div>
                   <p>{t('candidates.details.applicationDate')} {new Date(app.applicationDate).toLocaleDateString()}</p>
-                  <h5 className="mt-3 mb-2">{t('candidates.details.interviews')}</h5>
+                  <div className="d-flex justify-content-between align-items-center mt-3 mb-2">
+                    <h5 className="mb-0">{t('candidates.details.interviews')}</h5>
+                    <Button
+                      variant="outline-primary"
+                      size="sm"
+                      onClick={() => openCreateModal(app)}
+                      aria-label={t('interviews.addInterview')}
+                    >
+                      <PlusCircle size={14} className="me-1" />
+                      {t('interviews.addInterview')}
+                    </Button>
+                  </div>
                   {app.interviews?.length ? (
                     [...app.interviews]
                       .sort((a, b) => new Date(a.interviewDate) - new Date(b.interviewDate))
@@ -571,41 +681,8 @@ const CandidateDetails = ({ candidate, onClose, onApplicationRemoved }) => {
 
                   <div className="d-flex gap-2 justify-content-end flex-wrap">
                     {editingInterview != null && isInterviewDeletable(editingInterview) && (() => {
-                      // #region agent log
-                      const apps = candidateDetails?.applications ?? [];
-                      const interviewIdsPerApp = apps.map((a) => ({
-                        appId: a?.id,
-                        interviewIds: (a?.interviews || []).map((x) => (x == null ? 'null' : x.id))
-                      }));
-                      fetch('http://127.0.0.1:7242/ingest/01a6f721-0594-4e0b-a031-946eb64c655e', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                          location: 'CandidateDetails.js:appForEdit',
-                          message: 'before find',
-                          data: { editingInterviewId: editingInterview?.id, interviewIdsPerApp },
-                          timestamp: Date.now(),
-                          hypothesisId: 'post-fix'
-                        })
-                      }).catch(() => {});
-                      // #endregion
                       const appForEdit = candidateDetails?.applications?.find((a) =>
-                        (a.interviews || []).some((i) => {
-                          // #region agent log
-                          fetch('http://127.0.0.1:7242/ingest/01a6f721-0594-4e0b-a031-946eb64c655e', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({
-                              location: 'CandidateDetails.js:some(i)',
-                              message: 'inside some callback',
-                              data: { iIsNull: i == null, iId: i != null ? i.id : undefined },
-                              timestamp: Date.now(),
-                              hypothesisId: 'post-fix'
-                            })
-                          }).catch(() => {});
-                          // #endregion
-                          return i != null && i.id === editingInterview.id;
-                        })
+                        (a.interviews || []).some((i) => i != null && i.id === editingInterview.id)
                       );
                       return (
                         <Button
@@ -675,6 +752,160 @@ const CandidateDetails = ({ candidate, onClose, onApplicationRemoved }) => {
                     {deleteLoading ? t('interviews.deleting') : t('interviews.confirmDelete')}
                   </Button>
                 </div>
+              </Modal.Body>
+            </Modal>
+
+            <Modal show={!!creatingForApplication} onHide={closeCreateModal}>
+              <Modal.Header closeButton>
+                <Modal.Title>{t('interviews.createTitle')}</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                {createError && <Alert variant="danger">{createError}</Alert>}
+                <Form onSubmit={handleCreateSubmit}>
+                  <Form.Group className="mb-2">
+                    <Form.Label>{t('interviews.application')}</Form.Label>
+                    <Form.Control
+                      type="text"
+                      value={creatingForApplication?.position?.title ?? ''}
+                      readOnly
+                      disabled
+                      aria-label={t('interviews.application')}
+                    />
+                  </Form.Group>
+
+                  <Form.Group className="mb-2">
+                    <Form.Label>{t('interviews.dateTime')}</Form.Label>
+                    <Form.Control
+                      type="datetime-local"
+                      name="interviewDate"
+                      value={createInterviewData.interviewDate}
+                      onChange={handleCreateInputChange}
+                      isInvalid={!!createValidationErrors.interviewDate}
+                      aria-label={t('interviews.dateTime')}
+                    />
+                    {createValidationErrors.interviewDate && (
+                      <Form.Control.Feedback type="invalid">
+                        {createValidationErrors.interviewDate}
+                      </Form.Control.Feedback>
+                    )}
+                  </Form.Group>
+
+                  <Form.Group className="mb-2">
+                    <Form.Label>{t('interviews.step')}</Form.Label>
+                    <Form.Select
+                      name="interviewStepId"
+                      value={createInterviewData.interviewStepId}
+                      onChange={handleCreateInputChange}
+                      disabled={createStepsLoading}
+                      isInvalid={!!createValidationErrors.interviewStepId}
+                      aria-label={t('interviews.step')}
+                    >
+                      <option value="">{t('interviews.selectStep')}</option>
+                      {createSteps.map((step) => (
+                        <option key={step.id} value={String(step.id)}>
+                          {step.name}
+                        </option>
+                      ))}
+                    </Form.Select>
+                    {createValidationErrors.interviewStepId && (
+                      <Form.Control.Feedback type="invalid">
+                        {createValidationErrors.interviewStepId}
+                      </Form.Control.Feedback>
+                    )}
+                  </Form.Group>
+
+                  <Form.Group className="mb-2">
+                    <Form.Label>{t('interviews.employee')}</Form.Label>
+                    <Form.Select
+                      name="employeeId"
+                      value={createInterviewData.employeeId}
+                      onChange={handleCreateInputChange}
+                      isInvalid={!!createValidationErrors.employeeId}
+                      aria-label={t('interviews.employee')}
+                    >
+                      <option value="">{t('interviews.selectEmployee')}</option>
+                      {employees.map((emp) => (
+                        <option key={emp.id} value={String(emp.id)}>
+                          {emp.name} ({emp.email})
+                        </option>
+                      ))}
+                    </Form.Select>
+                    {createValidationErrors.employeeId && (
+                      <Form.Control.Feedback type="invalid">
+                        {createValidationErrors.employeeId}
+                      </Form.Control.Feedback>
+                    )}
+                  </Form.Group>
+
+                  <Form.Group className="mb-2">
+                    <Form.Label>{t('interviews.result')}</Form.Label>
+                    <Form.Select
+                      name="result"
+                      value={createInterviewData.result}
+                      onChange={handleCreateInputChange}
+                      aria-label={t('interviews.result')}
+                    >
+                      {INTERVIEW_RESULTS.map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </Form.Select>
+                  </Form.Group>
+
+                  <Form.Group className="mb-2">
+                    <Form.Label>{t('interviews.score')}</Form.Label>
+                    <div role="group" aria-label={t('interviews.score')}>
+                      {[1, 2, 3, 4, 5].map((star) => (
+                        <span
+                          key={star}
+                          role="button"
+                          tabIndex={0}
+                          style={{
+                            cursor: 'pointer',
+                            color: (createInterviewData.score ?? 0) >= star ? 'gold' : 'gray',
+                            marginRight: 2
+                          }}
+                          onClick={() => handleCreateScoreChange(star)}
+                          onKeyDown={(e) => e.key === 'Enter' && handleCreateScoreChange(star)}
+                          aria-label={t('interviews.scoreLabel', { star })}
+                        >
+                          ★
+                        </span>
+                      ))}
+                    </div>
+                  </Form.Group>
+
+                  <Form.Group className="mb-2">
+                    <Form.Label>{t('interviews.notes', { max: NOTES_MAX_LENGTH })}</Form.Label>
+                    <Form.Control
+                      as="textarea"
+                      rows={3}
+                      name="notes"
+                      value={createInterviewData.notes}
+                      onChange={handleCreateInputChange}
+                      isInvalid={!!createValidationErrors.notes}
+                      aria-label={t('interviews.notes', { max: NOTES_MAX_LENGTH })}
+                    />
+                    <Form.Text className="text-muted">
+                      {(createInterviewData.notes || '').length}/{NOTES_MAX_LENGTH}
+                    </Form.Text>
+                    {createValidationErrors.notes && (
+                      <Form.Control.Feedback type="invalid">
+                        {createValidationErrors.notes}
+                      </Form.Control.Feedback>
+                    )}
+                  </Form.Group>
+
+                  <div className="d-flex gap-2 justify-content-end">
+                    <Button variant="secondary" onClick={closeCreateModal} disabled={createLoading}>
+                      {t('common.cancel')}
+                    </Button>
+                    <Button variant="primary" type="submit" disabled={createLoading}>
+                      {createLoading ? t('interviews.saving') : t('interviews.save')}
+                    </Button>
+                  </div>
+                </Form>
               </Modal.Body>
             </Modal>
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -218,7 +218,11 @@
     "updateSuccess": "Interview updated successfully!",
     "deleteSuccess": "Interview deleted successfully.",
     "editInterview": "Edit interview",
-    "deleteInterview": "Delete interview"
+    "deleteInterview": "Delete interview",
+    "createTitle": "Create Interview",
+    "addInterview": "Add interview",
+    "createSuccess": "Interview created successfully",
+    "failedToCreate": "Failed to create interview"
   },
   "fileUploader": {
     "upload": "Upload File",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -218,7 +218,11 @@
     "updateSuccess": "¡Entrevista actualizada con éxito!",
     "deleteSuccess": "Entrevista eliminada con éxito.",
     "editInterview": "Editar entrevista",
-    "deleteInterview": "Eliminar entrevista"
+    "deleteInterview": "Eliminar entrevista",
+    "createTitle": "Crear Entrevista",
+    "addInterview": "Añadir entrevista",
+    "createSuccess": "Entrevista creada exitosamente",
+    "failedToCreate": "Error al crear la entrevista"
   },
   "fileUploader": {
     "upload": "Subir Archivo",

--- a/frontend/src/services/interviewService.js
+++ b/frontend/src/services/interviewService.js
@@ -3,6 +3,40 @@ import axios from 'axios';
 const API_BASE_URL = 'http://localhost:3010';
 
 /**
+ * Creates a new interview for a candidate's application
+ * @param {number} candidateId - The ID of the candidate
+ * @param {Object} interviewData - The interview data (applicationId, interviewStepId, employeeId, interviewDate required; result, score, notes optional)
+ * @returns {Promise<Object>} The created interview
+ * @throws {Error} If the API call fails
+ */
+export const createInterview = async (candidateId, interviewData) => {
+    try {
+        const response = await axios.post(
+            `${API_BASE_URL}/candidates/${candidateId}/interviews`,
+            interviewData,
+            {
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }
+        );
+        return response.data;
+    } catch (error) {
+        if (error.response) {
+            // Server responded with error status
+            const errorMessage = error.response.data?.error || error.response.data?.message || 'Failed to create interview';
+            throw new Error(errorMessage);
+        } else if (error.request) {
+            // Request was made but no response received
+            throw new Error('Network error: Could not connect to server');
+        } else {
+            // Something else happened
+            throw new Error(error.message || 'An unexpected error occurred');
+        }
+    }
+};
+
+/**
  * Updates an existing interview for a candidate
  * @param {number} candidateId - The ID of the candidate
  * @param {number} interviewId - The ID of the interview to update

--- a/openspec/changes/archive/2026-06-09-create-interview/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-create-interview/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-create-interview/design.md
+++ b/openspec/changes/archive/2026-06-09-create-interview/design.md
@@ -1,0 +1,110 @@
+## Context
+
+The LTI platform already supports editing (`PATCH`) and deleting (`DELETE`) interviews, plus listing them in the Candidate Details pane. There is no endpoint or UI to **create** a new interview. This change adds the create operation following the same Domain-Driven Design layered architecture and conventions established by the edit/delete features.
+
+The `Interview` domain entity (`backend/src/domain/models/Interview.ts`) and the `Interview` table (`schema.prisma`) already exist. The entity's `save()` method already branches on the presence of `id`: it **inserts** when `id` is absent and **updates** when present. Therefore no schema migration and no new persistence primitive are required — `createInterview` simply constructs an `Interview` with no `id` and calls `save()`.
+
+An interview always belongs to an **Application** (a candidate's participation in a specific position's process). The create endpoint is nested under the candidate (`/candidates/{candidateId}/interviews`) for UI ergonomics, but the interview is attached to a specific `applicationId` supplied in the body, which must be validated to belong to that candidate.
+
+Relevant existing code to mirror:
+- `validateInterviewUpdateData` and `validateAssignCandidateToPositionData` (allow-list pattern) in `validator.ts`.
+- `updateInterview` / `deleteInterview` in `interviewService.ts` (lookup + business-rule validation + domain error messages).
+- `updateInterviewController` in `interviewController.ts` (param parsing, validator call, domain-error → HTTP mapping).
+- The edit modal and `updateInterview` service call on the frontend.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `POST /candidates/{candidateId}/interviews` returning `201` with the created interview.
+- Enforce required fields and foreign-key ownership integrity before any DB write (application↔candidate, step↔position flow, active employee).
+- Reuse existing validation rules for `score`, `notes`, `result`, and `interviewDate`.
+- Provide an "Add interview" UI per application that reuses the edit-form controls and is fully internationalized (en/es).
+- Keep error shape (`{ message, error }`) and status codes consistent with edit/delete.
+
+**Non-Goals:**
+- No authentication/authorization (none exists in the codebase; not added here).
+- No schema migration or change to the `Interview` entity.
+- No bulk interview creation (single create only).
+- No interview rescheduling/audit-log features (covered by edit; out of scope here).
+- No change to existing edit/delete/list behavior.
+
+## Decisions
+
+### 1. Nested route under candidate, application supplied in body
+**Decision**: Endpoint is `POST /candidates/{candidateId}/interviews`; `applicationId` is a **required** body field validated to belong to the path `candidateId`.
+
+**Rationale**: Matches the UI (recruiters act from a candidate's detail pane) and the sibling edit/delete routes, while preserving the true ownership model (interview → application). Validating `application.candidateId === candidateId` prevents cross-candidate/cross-process corruption.
+
+**Alternatives considered**: `POST /applications/{applicationId}/interviews` — truer to the model but mismatched with the existing candidate-scoped routes and the UI entry point.
+
+### 2. Reuse the domain `save()` insert path
+**Decision**: `createInterview` builds `new Interview({...})` without an `id` and calls `save()`.
+
+**Rationale**: `save()` already implements insert when `id` is absent; reusing it avoids duplicating persistence logic and keeps DDD encapsulation. No new repository method needed.
+
+**Alternatives considered**: Direct Prisma `create` in the service — bypasses the domain model and violates the layering used everywhere else.
+
+### 3. Required-field validation with an allow-list
+**Decision**: `validateInterviewCreateData` requires `applicationId`, `interviewStepId`, `employeeId`, `interviewDate`; treats `result`, `score`, `notes` as optional; and rejects any unexpected field (allow-list), mirroring `validateAssignCandidateToPositionData`.
+
+**Rationale**: Create needs the FK fields present (unlike the partial-update validator where all are optional). The allow-list prevents silent acceptance of typo'd or malicious fields and returns `400`.
+
+**Alternatives considered**: Reuse `validateInterviewUpdateData` as-is — rejected because it makes the required FK fields optional, which is wrong for create.
+
+### 4. Business-rule validation order and error mapping
+**Decision**: In the service, validate in this order, throwing domain errors with stable messages: candidate exists (`not found` → 404); application exists and `application.candidateId === candidateId` (`not found` / `does not belong` → 404); interview step exists (`not found` → 404) and belongs to the position's `interviewFlowId` (`does not belong to the position's interview flow` → 400); employee exists (`not found` → 404) and `isActive` (`is not active` → 400). The controller maps message substrings to status codes exactly as `updateInterviewController` does.
+
+**Rationale**: Consistency with edit/delete; fail before any write; keep `{ message, error }` shape.
+
+### 5. `result` defaults to `Pending`
+**Decision**: When `result` is omitted, persist `Pending`. When provided, it must be one of `Pending` / `Passed` / `Failed` (or `null`).
+
+**Rationale**: Matches the ticket's acceptance criteria and the interview lifecycle default.
+
+### 6. Route ordering
+**Decision**: Register `POST /:candidateId/interviews` **before** any `/:id` route in `candidateRoutes.ts`.
+
+**Rationale**: Express matches routes in registration order; placing the nested interview route first prevents `/:id` from shadowing `:candidateId`.
+
+### 7. Frontend create modal reuses the edit form
+**Decision**: Add an "Add interview" action per application section that opens a React Bootstrap modal reusing the edit modal's controls (date/time `datetime-local`, step scoped to the application's flow, employee, result, score star-rating, notes), converting `datetime-local` → ISO before submit. On success, append the created interview to that application's list and show a success message; on validation error, keep the modal open with inline errors; disable the submit during the request.
+
+**Rationale**: Maximizes reuse with the proven edit UX, keeps the two flows visually consistent, and scopes the step dropdown correctly to the chosen application's interview flow.
+
+**Alternatives considered**: A separate page or inline form — more navigation/clutter, less consistent with the existing edit modal.
+
+### 8. Internationalization
+**Decision**: Add only the missing create keys (`interviews.createTitle`, `interviews.addInterview`, `interviews.createSuccess`, `interviews.failedToCreate`) to `en.json`/`es.json` and reuse existing field-label keys. No hardcoded strings.
+
+**Rationale**: The edit feature already scaffolded shared field labels; only create-specific copy is missing.
+
+## Risks / Trade-offs
+
+**[Risk] Cross-candidate/cross-process data corruption** → Mitigation: validate `application.candidateId === candidateId` and `interviewStep.interviewFlowId === position.interviewFlowId` before writing.
+
+**[Risk] Route shadowing by `/:id`** → Mitigation: register the nested route first; cover with an integration test.
+
+**[Risk] datetime-local ↔ ISO conversion / timezone drift** → Mitigation: reuse the edit feature's conversion helper; convert to ISO 8601 (UTC) before submit; validate ISO server-side.
+
+**[Risk] Step dropdown showing steps from the wrong flow** → Mitigation: scope step options to the selected application's position interview flow.
+
+**[Trade-off] Bounded extra lookups (candidate, application, position, step, employee) vs. integrity** → Accept a few indexed point lookups to guarantee FK ownership; no N+1 (single insert, bounded reads).
+
+**[Trade-off] New dedicated create validator vs. reusing the update validator** → Accept a small amount of duplication to get correct required-field semantics for create.
+
+## Migration Plan
+
+**Deployment steps:**
+1. Deploy backend (validator, service, controller, route) — no DB migration (existing `Interview` table/`save()` insert path).
+2. Deploy frontend (service method, create modal, i18n keys).
+3. Verify endpoint reachable and `201` on a valid create.
+
+**Rollback:** Revert backend and frontend changes; the create endpoint and "Add interview" action disappear while edit/delete/list remain functional. No data migration to roll back.
+
+**Testing strategy:** TDD unit tests (validator, service happy path + every error branch, controller status mapping); integration test for `POST /candidates/:candidateId/interviews`; manual curl matrix with DB restoration; frontend component test + Playwright E2E for open/validation/success/cancel/error.
+
+## Open Questions
+
+- Should `applicationId` selection be hidden when "Add interview" is launched from within a specific application section (pre-selected and locked) vs. shown as a dropdown? Assumption: pre-select the launching application's context; still send `applicationId` in the body.
+- Should audit logging be added for interview creation? Out of scope (future enhancement).
+- Should concurrent-creation/idempotency protection be added? Out of scope; not required by current usage.

--- a/openspec/changes/archive/2026-06-09-create-interview/proposal.md
+++ b/openspec/changes/archive/2026-06-09-create-interview/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Recruiters can already **edit** (`PATCH`) and **delete** (`DELETE`) interviews, but there is no way to **create** a new interview from the system. Today recruiters track upcoming evaluation meetings outside the platform, which leads to incomplete records and a fragmented recruitment workflow. SCRUM-86 closes this gap by letting recruiters schedule a new interview for a candidate, against a specific application (the candidate's participation in a position's process), directly from the Candidate Details pane.
+
+## What Changes
+
+- **New Backend API Endpoint**: `POST /candidates/{candidateId}/interviews` creates a new interview for one of the candidate's applications and returns `201 Created` with the created interview.
+- **New Backend Validation**: `validateInterviewCreateData()` enforces required fields (`applicationId`, `interviewStepId`, `employeeId`, `interviewDate`), optional-field rules (`result`, `score`, `notes`), and rejects unexpected fields via an allow-list.
+- **New Backend Service Method**: `createInterview(candidateId, interviewData)` enforces business rules — candidate exists; application exists and belongs to the candidate; interview step exists and belongs to the application's position's interview flow; employee exists and is active — then persists via the existing `Interview.save()` insert path.
+- **New Backend Controller**: `createInterviewController` parses/validates `candidateId`, runs body validation, maps domain errors to HTTP status codes, and returns `201`.
+- **New Route**: `POST /:candidateId/interviews` registered in `candidateRoutes.ts` **before** `/:id` to avoid route shadowing.
+- **New Frontend Service Method**: `createInterview(candidateId, interviewData)` in `interviewService.js`.
+- **Enhanced Frontend UI**: An "Add interview" action per application section in `CandidateDetails.js`, opening a create modal that reuses the edit form controls (application context, date/time, step scoped to the flow, employee, result, score, notes), converts `datetime-local` → ISO before submit, appends the new interview on success, and shows inline validation/loading states.
+- **i18n**: Add the missing create keys (`interviews.createTitle`, `interviews.addInterview`, `interviews.createSuccess`, `interviews.failedToCreate`) to `en.json` and `es.json`, reusing existing field labels. No hardcoded UI strings.
+- **Documentation**: Add the `post:` operation under `/candidates/{candidateId}/interviews` and a `CreateInterviewRequest` schema (`additionalProperties: false`) to the API spec; reuse `InterviewResponse` for the body.
+
+**No schema migration required** — the `Interview` entity already exists in `schema.prisma` and `domain/models/Interview.ts`, and `save()` already supports insert when no `id` is present.
+
+## Capabilities
+
+### New Capabilities
+- `create-interview`: Create a new interview for a candidate against one of their applications via REST API and the Candidate Details UI, with full server-side validation, foreign-key ownership enforcement (application↔candidate, step↔position flow, active employee), and i18n.
+
+### Modified Capabilities
+_None._ The `Interview` data model and existing edit/delete capabilities are unchanged; this change only adds the create operation.
+
+## Impact
+
+**Backend:**
+- `backend/src/application/validator.ts` — add `validateInterviewCreateData()`.
+- `backend/src/application/services/interviewService.ts` — add `createInterview()`.
+- `backend/src/presentation/controllers/interviewController.ts` — add `createInterviewController`.
+- `backend/src/routes/candidateRoutes.ts` — register `POST /:candidateId/interviews` before `/:id`.
+- `backend/src/domain/models/Interview.ts` — no change (`save()` already supports insert).
+- Test suites: new validator, service, controller unit tests + integration test for the endpoint.
+
+**Frontend:**
+- `frontend/src/services/interviewService.js` — add `createInterview()`.
+- `frontend/src/components/CandidateDetails.js` — add "Add interview" action + create modal, state management, ISO conversion, success/error handling.
+- `frontend/src/i18n/locales/en.json` & `es.json` — add missing create keys.
+
+**Documentation:**
+- `docs/api-spec.yml` — add `post:` for `/candidates/{candidateId}/interviews` (`201`/`400`/`404`/`500`) and `CreateInterviewRequest` schema.
+- `docs/data-model.md` — no change (Interview already documented).
+
+**Security / NFR:** Endpoints remain `Public` (no auth layer exists; none added). All input validated/sanitized server-side; error shape `{ message, error }` and status codes match the existing edit/delete endpoints; single insert with bounded lookups (no N+1).
+
+**No Breaking Changes** — purely additive; existing endpoints and data structures are untouched.

--- a/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/reports/2026-06-09-step-9-unit-test-and-db-verification.md
+++ b/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/reports/2026-06-09-step-9-unit-test-and-db-verification.md
@@ -1,0 +1,79 @@
+# Step 9: Unit Test and DB Verification Report
+
+**Date:** 2026-06-09
+**Feature:** SCRUM-86 Create Interview
+**Branch:** feature/SCRUM-86-create-interview
+
+## Test Results Summary
+
+### Full Backend Test Suite
+
+```
+Test Suites: 4 failed (pre-existing), 10 passed, 14 total
+Tests:       248 passed, 0 failed, 248 total
+Snapshots:   0 total
+Time:        ~3.25 s
+```
+
+### Pre-existing Failures (not related to this feature)
+
+All 4 failing test suites fail due to `positionController.ts` referencing undefined symbols (`validateAssignCandidateToPositionData` and `assignCandidateToPositionService`). These failures pre-date this feature and were documented as known issues in the task spec.
+
+Failing suites:
+- `src/presentation/controllers/positionController.assignCandidate.test.ts`
+- `src/presentation/controllers/__tests__/candidateController.test.ts`
+- `src/presentation/controllers/positionController.test.ts`
+- `src/routes/positionRoutes.integration.test.ts`
+
+### New Tests Added by This Feature
+
+| Module | Tests Added | Result |
+|--------|------------|--------|
+| `validator.test.ts` (`validateInterviewCreateData`) | 30 | All PASS |
+| `interviewService.test.ts` (`createInterview`) | 10 | All PASS |
+| `interviewController.test.ts` (`createInterviewController`) | 11 | All PASS |
+| `candidateRoutes.integration.test.ts` | 5 | All PASS |
+
+**Total new tests: 56**
+
+### Targeted Module Tests
+
+```
+validator tests:    132 passed (30 new)
+interviewService:   28 passed (10 new)
+interviewController: 32 passed (11 new)
+candidateRoutes integration: 5 passed (5 new)
+```
+
+## Database State Verification
+
+Unit tests use mocked domain models and Prisma client. No actual database writes occur during the unit test suite. The DB state is unchanged by running tests.
+
+### Prisma Mock Verification
+
+- All `Interview.save()`, `Interview.findOne()`, `Interview.delete()` calls are mocked in tests
+- No real DB connections are made during unit test execution
+- The `prisma.interview.create` code path is covered by the mock returning the created record
+
+## Code Coverage
+
+New functions added:
+- `validateInterviewCreateData` in `validator.ts` — covered by 30 test cases
+- `createInterview` in `interviewService.ts` — covered by 10 test cases (happy path + all error branches)
+- `createInterviewController` in `interviewController.ts` — covered by 11 test cases (201, 400 x3, 404 x5, 500)
+
+All branches in `createInterviewController` are covered:
+- 400 from invalid candidateId (NaN check)
+- 400 from validator throw
+- 400 from business rule: step not in flow
+- 400 from business rule: employee not active
+- 404 from: candidate/application/step/employee not found
+- 404 from: application does not belong to candidate
+- 500 from: unexpected error
+
+## Conclusion
+
+- 0 new test failures introduced
+- 56 new tests all passing
+- Pre-existing 4 test suite failures unaffected
+- Feature implementation is complete and all acceptance criteria tests pass

--- a/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/reports/CURL_TESTING.md
+++ b/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/reports/CURL_TESTING.md
@@ -1,0 +1,339 @@
+# Manual curl Testing — POST /candidates/:candidateId/interviews
+
+**Date:** 2026-06-09
+**Backend server:** http://localhost:3010
+**Feature:** SCRUM-86 Create Interview
+
+## Setup
+
+Backend started with: `npm run dev` (port 3010)
+
+## Test Data Used
+
+- Candidate 1 (John Doe) with:
+  - Application 1 → Position 1 (Senior Full-Stack Engineer), interviewFlow id=1
+    - Valid step IDs: 1 (Initial Screening), 2 (Technical Interview), 3 (Manager Interview)
+  - Application 2 → Position 2 (Data Scientist)
+- Application 4 belongs to Candidate 3 (not Candidate 1)
+- Employee 1 (Alice Johnson, isActive=true)
+- Employee 7 (Emma Davis, temporarily set isActive=false for test 15, then restored)
+
+---
+
+## TEST 1: POST success (full payload) → 201
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z","result":"Pending","score":4,"notes":"Strong candidate"}'
+```
+
+**Response (201):**
+```json
+{
+    "id": 27,
+    "applicationId": 1,
+    "interviewStepId": 1,
+    "employeeId": 1,
+    "interviewDate": "2026-06-20T10:00:00.000Z",
+    "result": "Pending",
+    "score": 4,
+    "notes": "Strong candidate"
+}
+```
+DB cleanup: `DELETE interview WHERE id=27` — done.
+
+---
+
+## TEST 2: POST success (minimal payload, result defaults to Pending) → 201
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":2,"employeeId":1,"interviewDate":"2026-06-21T10:00:00Z"}'
+```
+
+**Response (201):**
+```json
+{
+    "id": 28,
+    "applicationId": 1,
+    "interviewStepId": 2,
+    "employeeId": 1,
+    "interviewDate": "2026-06-21T10:00:00.000Z",
+    "result": "Pending",
+    "score": null,
+    "notes": null
+}
+```
+Note: `result` defaults to `"Pending"` when omitted. DB cleanup: `DELETE interview WHERE id=28` — done.
+
+---
+
+## TEST 3: 400 - invalid candidateId format
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/abc/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "Invalid candidate ID format"
+}
+```
+
+---
+
+## TEST 4: 400 - missing required field (interviewDate)
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1}'
+```
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "interviewDate is required"
+}
+```
+
+---
+
+## TEST 5: 400 - unexpected field
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z","unknownField":"value"}'
+```
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "Unexpected field: unknownField"
+}
+```
+
+---
+
+## TEST 6: 400 - invalid score (out of range)
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z","score":10}'
+```
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "Score must be between 0 and 5"
+}
+```
+
+---
+
+## TEST 7: 400 - notes too long (> 1000 chars)
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z","notes":"aaa...1001 chars"}'
+```
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "Notes must not exceed 1000 characters"
+}
+```
+
+---
+
+## TEST 8: 400 - invalid result value
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z","result":"InvalidValue"}'
+```
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "Invalid result value"
+}
+```
+
+---
+
+## TEST 9: 404 - candidate not found
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/9999/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**Response (404):**
+```json
+{
+    "message": "Resource not found",
+    "error": "Candidate not found"
+}
+```
+
+---
+
+## TEST 10: 404 - application not found
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":9999,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**Response (404):**
+```json
+{
+    "message": "Resource not found",
+    "error": "Application not found"
+}
+```
+
+---
+
+## TEST 11: 404 - application not owned by candidate
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":4,"interviewStepId":1,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+(Application 4 belongs to Candidate 3, not Candidate 1)
+
+**Response (404):**
+```json
+{
+    "message": "Resource not found",
+    "error": "Application does not belong to the specified candidate"
+}
+```
+
+---
+
+## TEST 12: 404 - step not found
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":9999,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**Response (404):**
+```json
+{
+    "message": "Resource not found",
+    "error": "Interview step not found"
+}
+```
+
+---
+
+## TEST 13: 404 - employee not found
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":9999,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**Response (404):**
+```json
+{
+    "message": "Resource not found",
+    "error": "Employee not found"
+}
+```
+
+---
+
+## TEST 14: 400 - step not in position's flow
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":4,"employeeId":1,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+(Step 4 belongs to interview flow 2, but Application 1 is in Position 1 which uses flow 1)
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "Interview step does not belong to the position's interview flow"
+}
+```
+
+---
+
+## TEST 15: 400 - employee not active
+
+Temporarily set employee 7 (Emma Davis) to `isActive=false`, then:
+
+```bash
+curl -s -X POST http://localhost:3010/candidates/1/interviews \
+  -H "Content-Type: application/json" \
+  -d '{"applicationId":1,"interviewStepId":1,"employeeId":7,"interviewDate":"2026-06-20T10:00:00Z"}'
+```
+
+**Response (400):**
+```json
+{
+    "message": "Validation error",
+    "error": "Employee is not active"
+}
+```
+
+Employee 7 restored to `isActive=true` after test.
+
+---
+
+## DB Restoration
+
+- Interviews created during testing (IDs 27 and 28) were deleted after tests.
+- Employee 7 `isActive` restored to `true` after test 15.
+- Final DB state matches pre-test baseline.
+
+## Summary
+
+| Test | Expected | Actual | Pass? |
+|------|----------|--------|-------|
+| Full payload | 201 + created interview | 201 + interview | YES |
+| Minimal (result defaults) | 201 + result=Pending | 201 + result=Pending | YES |
+| Invalid candidateId | 400 | 400 | YES |
+| Missing field | 400 | 400 | YES |
+| Unexpected field | 400 | 400 | YES |
+| Score out of range | 400 | 400 | YES |
+| Notes too long | 400 | 400 | YES |
+| Invalid result | 400 | 400 | YES |
+| Candidate not found | 404 | 404 | YES |
+| Application not found | 404 | 404 | YES |
+| App not owned by candidate | 404 | 404 | YES |
+| Step not found | 404 | 404 | YES |
+| Employee not found | 404 | 404 | YES |
+| Step not in flow | 400 | 400 | YES |
+| Employee not active | 400 | 400 | YES |
+
+All 15 curl tests passed.

--- a/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/reports/E2E_TESTING.md
+++ b/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/reports/E2E_TESTING.md
@@ -1,0 +1,44 @@
+# E2E Testing Report — create-interview
+
+- Date: 2026-06-09
+- Change: create-interview
+- Agent: Claude (main session, Playwright MCP)
+- Candidate tested: John Doe (id=1)
+- Backend: http://localhost:3010
+- Frontend: http://localhost:3000
+
+## Test Scenarios
+
+### Test 1: Successful create interview
+- Navigated to Candidates → View details for John Doe
+- Clicked "Add interview" on the Data Scientist application
+- Verified modal opened titled "Create Interview" with application pre-filled as "Data Scientist"
+- Filled: date=2026-07-15T10:00, step=Technical Interview, employee=Alice Johnson, notes="E2E test interview - will be deleted"
+- Clicked Save
+- **Result: PASS** — modal closed, "Interview created successfully" alert appeared, new interview row appeared in Data Scientist application list
+- Created interview ID: 29
+
+### Test 2: Cancel closes modal without API call
+- Clicked "Add interview" on the Senior Full-Stack Engineer application
+- Verified "Create Interview" modal opened
+- Clicked Cancel
+- Verified modal closed with no POST request sent (network log confirmed only 1 POST total from Test 1)
+- **Result: PASS**
+
+### Test 3: Validation errors on empty submit
+- Clicked "Add interview" on the Data Scientist application
+- Clicked Save without filling any fields
+- Verified modal remained open with inline errors:
+  - "Interview date is required" (below date field)
+  - "Interview step is required" (below step dropdown)
+  - "Employee is required" (below employee dropdown)
+- No API call was made
+- **Result: PASS**
+
+## Database State Restoration
+- Interview ID 29 deleted via `DELETE /candidates/1/interviews/29` after Test 1
+- DB confirmed restored (interview count back to pre-test baseline)
+
+## Outcome
+- All 3 E2E scenarios: **PASS**
+- No regressions observed in existing interview edit/delete flows

--- a/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/spec.md
+++ b/openspec/changes/archive/2026-06-09-create-interview/specs/create-interview/spec.md
@@ -1,0 +1,180 @@
+## ADDED Requirements
+
+### Requirement: Backend API supports interview creation
+The system SHALL provide a `POST` endpoint at `/candidates/{candidateId}/interviews` that accepts interview data, creates a new interview for one of the candidate's applications, and returns the created interview with HTTP `201`. The endpoint SHALL validate the request body, enforce foreign-key ownership and business rules, and return the error shape `{ message, error }` with the appropriate status code on failure.
+
+#### Scenario: Successful interview creation
+- **WHEN** a valid `POST` request is sent to `/candidates/{candidateId}/interviews` with `applicationId`, `interviewStepId`, `employeeId`, `interviewDate`, and optional `result`, `score`, `notes`
+- **THEN** the system SHALL insert a new interview record associated with the given application
+- **AND** the system SHALL return HTTP `201` with the created interview object (`id, applicationId, interviewStepId, employeeId, interviewDate, result, score, notes`)
+
+#### Scenario: Creation with minimal required fields
+- **WHEN** a valid `POST` request contains only the required fields (`applicationId`, `interviewStepId`, `employeeId`, `interviewDate`) and omits `result`
+- **THEN** the system SHALL create the interview with `result` defaulting to `Pending`
+- **AND** the system SHALL return HTTP `201` with the created interview
+
+#### Scenario: Invalid candidate ID format
+- **WHEN** a `POST` request is sent with a non-numeric `candidateId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate an invalid candidate ID format
+
+#### Scenario: Candidate not found
+- **WHEN** a `POST` request targets a `candidateId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the candidate was not found
+
+#### Scenario: Application not found
+- **WHEN** a `POST` request contains an `applicationId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the application was not found
+
+#### Scenario: Application does not belong to candidate
+- **WHEN** a `POST` request contains an `applicationId` that exists but whose `candidateId` does not equal the path `candidateId`
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the application does not belong to the specified candidate
+
+#### Scenario: Unexpected field rejected
+- **WHEN** a `POST` request body contains a field that is not part of the allowed create payload
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that an unexpected field was provided
+- **AND** no interview record SHALL be created
+
+### Requirement: Interview creation required-field validation
+The system SHALL require `applicationId`, `interviewStepId`, `employeeId`, and `interviewDate` on creation. Each missing required field SHALL result in HTTP `400` before any database write.
+
+#### Scenario: Missing applicationId
+- **WHEN** a `POST` request omits `applicationId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `applicationId` is required
+
+#### Scenario: Missing interviewStepId
+- **WHEN** a `POST` request omits `interviewStepId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `interviewStepId` is required
+
+#### Scenario: Missing employeeId
+- **WHEN** a `POST` request omits `employeeId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `employeeId` is required
+
+#### Scenario: Missing interviewDate
+- **WHEN** a `POST` request omits `interviewDate`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `interviewDate` is required
+
+#### Scenario: Non-integer foreign-key field
+- **WHEN** a `POST` request contains `applicationId`, `interviewStepId`, or `employeeId` that is not a positive integer
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the field must be a positive integer
+
+### Requirement: Interview creation field-value validation
+The system SHALL validate field values as follows: `interviewDate` must be a valid ISO 8601 date-time; `score` must be an integer between 0 and 5 inclusive or `null`; `notes` must be a string of at most 1000 characters or `null`; `result` must be one of `Pending`, `Passed`, `Failed` (or `null`, defaulting to `Pending` when omitted).
+
+#### Scenario: Interview date validation - valid ISO 8601
+- **WHEN** a `POST` request contains an `interviewDate` in valid ISO 8601 format (e.g., `2026-06-20T10:00:00Z`)
+- **THEN** the system SHALL accept the date and proceed with creation
+
+#### Scenario: Interview date validation - invalid format
+- **WHEN** a `POST` request contains an `interviewDate` that is not valid ISO 8601 or cannot be parsed
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the date is invalid
+
+#### Scenario: Score validation - valid range
+- **WHEN** a `POST` request contains a `score` that is an integer between 0 and 5 inclusive
+- **THEN** the system SHALL accept the score and proceed with creation
+
+#### Scenario: Score validation - out of range
+- **WHEN** a `POST` request contains a `score` less than 0 or greater than 5
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the score must be between 0 and 5
+
+#### Scenario: Score validation - null allowed
+- **WHEN** a `POST` request contains a `score` of `null`
+- **THEN** the system SHALL accept the null value and create the interview with `score` set to null
+
+#### Scenario: Notes validation - within length limit
+- **WHEN** a `POST` request contains `notes` of 1000 characters or fewer
+- **THEN** the system SHALL accept the notes and proceed with creation
+
+#### Scenario: Notes validation - exceeds length limit
+- **WHEN** a `POST` request contains `notes` exceeding 1000 characters
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate notes must not exceed 1000 characters
+
+#### Scenario: Result validation - valid value
+- **WHEN** a `POST` request contains a `result` of `Pending`, `Passed`, or `Failed`
+- **THEN** the system SHALL accept the result and proceed with creation
+
+#### Scenario: Result validation - invalid value
+- **WHEN** a `POST` request contains a `result` that is not one of the allowed values
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the result must be one of `Pending`, `Passed`, `Failed`
+
+#### Scenario: Result validation - default when omitted
+- **WHEN** a `POST` request omits `result`
+- **THEN** the system SHALL create the interview with `result` set to `Pending`
+
+### Requirement: Interview creation business-rule validation
+The system SHALL enforce that the interview step exists and belongs to the application's position's interview flow, and that the employee exists and is active, before creating the interview.
+
+#### Scenario: Interview step not found
+- **WHEN** a `POST` request contains an `interviewStepId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the interview step was not found
+
+#### Scenario: Interview step not in position's flow
+- **WHEN** a `POST` request contains an `interviewStepId` that exists but does not belong to the application's position's interview flow
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the interview step does not belong to the position's interview flow
+
+#### Scenario: Employee not found
+- **WHEN** a `POST` request contains an `employeeId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the employee was not found
+
+#### Scenario: Employee not active
+- **WHEN** a `POST` request contains an `employeeId` that exists but is not active (`isActive = false`)
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the employee is not active
+
+#### Scenario: Internal error
+- **WHEN** an unexpected error occurs while persisting the interview
+- **THEN** the system SHALL return HTTP `500`
+- **AND** the response SHALL not leak internal error details
+
+### Requirement: Frontend supports interview creation
+The frontend SHALL provide an "Add interview" action per application section in the Candidate Details pane that opens a modal allowing the recruiter to create a new interview for that application, fully internationalized with no hardcoded UI strings.
+
+#### Scenario: Add interview action appears per application
+- **WHEN** a candidate's details are displayed with one or more applications
+- **THEN** an "Add interview" action SHALL be visible for each application section
+- **AND** the action SHALL be clickable
+
+#### Scenario: Clicking Add interview opens the create modal
+- **WHEN** a recruiter clicks "Add interview" for an application
+- **THEN** a modal titled by the `interviews.createTitle` key SHALL open
+- **AND** the form SHALL include application context, interview date & time (`datetime-local`), interview step (scoped to the application's interview flow), employee, result, score (star rating), and notes
+
+#### Scenario: Successful creation
+- **WHEN** a recruiter fills valid values and submits the create form
+- **THEN** the frontend SHALL convert the `datetime-local` value to ISO 8601 and call the create API
+- **AND** on success the modal SHALL close, the new interview SHALL appear in that application's interview list, and a success message (`interviews.createSuccess`) SHALL be displayed
+
+#### Scenario: Cancel creation
+- **WHEN** a recruiter clicks Cancel in the create modal
+- **THEN** the modal SHALL close without calling the API
+- **AND** the interview list SHALL remain unchanged
+
+#### Scenario: Validation errors displayed in modal
+- **WHEN** a recruiter submits invalid data (e.g., score out of range, notes too long, missing required field)
+- **THEN** validation errors SHALL be displayed inline
+- **AND** the modal SHALL remain open for correction
+
+#### Scenario: Server or network error handling
+- **WHEN** the create API call fails
+- **THEN** an error message (`interviews.failedToCreate`) SHALL be displayed
+- **AND** the interview list SHALL remain unchanged
+
+#### Scenario: Loading state during creation
+- **WHEN** a recruiter submits the create form
+- **THEN** the submit button SHALL show a loading/disabled state during the API call

--- a/openspec/changes/archive/2026-06-09-create-interview/tasks.md
+++ b/openspec/changes/archive/2026-06-09-create-interview/tasks.md
@@ -1,0 +1,194 @@
+## 0. Setup: Create Feature Branch (MANDATORY - FIRST STEP)
+
+- [x] 0.1 Create feature branch `feature/SCRUM-86-create-interview` from the base branch
+- [x] 0.2 Verify branch creation and current branch status
+
+## 1. Backend: Validator Tests (TDD)
+
+- [x] 1.1 Write failing tests for `validateInterviewCreateData` - valid full payload (all fields)
+- [x] 1.2 Write failing tests for `validateInterviewCreateData` - valid minimal payload (required fields only, `result` omitted)
+- [x] 1.3 Write failing tests for `validateInterviewCreateData` - missing required `applicationId` (400)
+- [x] 1.4 Write failing tests for `validateInterviewCreateData` - missing required `interviewStepId` (400)
+- [x] 1.5 Write failing tests for `validateInterviewCreateData` - missing required `employeeId` (400)
+- [x] 1.6 Write failing tests for `validateInterviewCreateData` - missing required `interviewDate` (400)
+- [x] 1.7 Write failing tests for `validateInterviewCreateData` - non-integer FK fields (applicationId/interviewStepId/employeeId)
+- [x] 1.8 Write failing tests for `validateInterviewCreateData` - invalid `interviewDate` format (non-ISO 8601)
+- [x] 1.9 Write failing tests for `validateInterviewCreateData` - score out of range (< 0, > 5) and null allowed
+- [x] 1.10 Write failing tests for `validateInterviewCreateData` - notes length > 1000 and null allowed
+- [x] 1.11 Write failing tests for `validateInterviewCreateData` - result invalid value and valid values (Pending/Passed/Failed)
+- [x] 1.12 Write failing tests for `validateInterviewCreateData` - unexpected/extra field rejected (allow-list)
+
+## 2. Backend: Validator Implementation
+
+- [x] 2.1 Implement `validateInterviewCreateData` in `validator.ts` - basic structure with allow-list of expected fields
+- [x] 2.2 Require `applicationId`, `interviewStepId`, `employeeId`, `interviewDate` (all positive integers / valid date)
+- [x] 2.3 Validate `interviewDate` is valid ISO 8601 format
+- [x] 2.4 Validate optional `score` (integer 0-5 inclusive or null)
+- [x] 2.5 Validate optional `notes` (string max 1000 characters or null)
+- [x] 2.6 Validate optional `result` (one of Pending/Passed/Failed or null; defaults to Pending downstream)
+- [x] 2.7 Reject any field not in the allow-list with a clear error
+- [x] 2.8 Run validator tests and verify all pass
+
+## 3. Backend: Service Tests (TDD)
+
+- [x] 3.1 Write failing tests for `createInterview` - successful creation with all fields
+- [x] 3.2 Write failing tests for `createInterview` - successful creation with minimal fields (result defaults to Pending)
+- [x] 3.3 Write failing tests for `createInterview` - candidate not found (404)
+- [x] 3.4 Write failing tests for `createInterview` - application not found (404)
+- [x] 3.5 Write failing tests for `createInterview` - application does not belong to candidate (404)
+- [x] 3.6 Write failing tests for `createInterview` - interview step not found (404)
+- [x] 3.7 Write failing tests for `createInterview` - interview step does not belong to position's flow (400)
+- [x] 3.8 Write failing tests for `createInterview` - employee not found (404)
+- [x] 3.9 Write failing tests for `createInterview` - employee is not active (400)
+- [x] 3.10 Write failing tests for `createInterview` - database/persistence error handling (500)
+
+## 4. Backend: Service Implementation
+
+- [x] 4.1 Add `createInterview(candidateId, interviewData)` to `interviewService.ts`
+- [x] 4.2 Validate candidate exists (404 if not)
+- [x] 4.3 Validate application exists and `application.candidateId === candidateId` (404 if not / not owned)
+- [x] 4.4 Validate interview step exists (404) and belongs to the application's position's `interviewFlowId` (400)
+- [x] 4.5 Validate employee exists (404) and is active `isActive = true` (400)
+- [x] 4.6 Apply `result` default of `Pending` when omitted
+- [x] 4.7 Construct `new Interview({...})` without `id` and persist via `save()` (insert path)
+- [x] 4.8 Add error handling for persistence errors (500)
+- [x] 4.9 Return the created interview object
+- [x] 4.10 Run service tests and verify all pass
+
+## 5. Backend: Controller Tests (TDD)
+
+- [x] 5.1 Write failing tests for `createInterviewController` - successful creation (201 response)
+- [x] 5.2 Write failing tests for `createInterviewController` - invalid candidate ID format (400)
+- [x] 5.3 Write failing tests for `createInterviewController` - body validation error (400)
+- [x] 5.4 Write failing tests for `createInterviewController` - candidate not found (404)
+- [x] 5.5 Write failing tests for `createInterviewController` - application not found / not owned by candidate (404)
+- [x] 5.6 Write failing tests for `createInterviewController` - interview step not found (404)
+- [x] 5.7 Write failing tests for `createInterviewController` - interview step not in flow (400)
+- [x] 5.8 Write failing tests for `createInterviewController` - employee not found (404)
+- [x] 5.9 Write failing tests for `createInterviewController` - employee not active (400)
+- [x] 5.10 Write failing tests for `createInterviewController` - server error (500)
+
+## 6. Backend: Controller Implementation
+
+- [x] 6.1 Add `createInterviewController` to `interviewController.ts`
+- [x] 6.2 Extract and validate `candidateId` from URL params (400 if NaN)
+- [x] 6.3 Extract interview data from request body
+- [x] 6.4 Integrate validator call (`validateInterviewCreateData`) → 400 on throw
+- [x] 6.5 Integrate service call (`createInterview`)
+- [x] 6.6 Add success response `201 Created` with the created interview
+- [x] 6.7 Map domain errors to HTTP status: `not found` → 404; `is not active` / `does not belong to the position's interview flow` → 400; else 500
+- [x] 6.8 Use try-catch consistent with `updateInterviewController` and the `{ message, error }` shape
+- [x] 6.9 Run controller tests and verify all pass
+
+## 7. Backend: Route and Integration
+
+- [x] 7.1 Import `createInterviewController` in `candidateRoutes.ts`
+- [x] 7.2 Register `router.post('/:candidateId/interviews', createInterviewController)`
+- [x] 7.3 Ensure the route is registered BEFORE any `/:id` route to avoid route shadowing
+- [x] 7.4 Write integration test for `POST /candidates/:candidateId/interviews` (success + key error cases)
+- [x] 7.5 Verify route registration and endpoint accessibility
+
+## 8. Backend: Review and Update Existing Unit Tests (MANDATORY)
+
+- [x] 8.1 Review existing interview-related unit tests (edit/delete) for compatibility
+- [x] 8.2 Review existing candidate- and application-related unit tests
+- [x] 8.3 Update existing tests if necessary to remain compatible with the new create functionality
+- [x] 8.4 Verify no existing tests are broken by the new changes
+- [x] 8.5 Ensure existing test coverage is maintained
+
+## 9. Backend: Run Unit Tests and Verify Database State (MANDATORY)
+
+- [x] 9.1 Capture pre-test database baseline for impacted entities (Interview counts, etc.)
+- [x] 9.2 Run targeted unit tests for changed modules (validator, service, controller)
+- [x] 9.3 Run the required broader backend test suite and record totals/failures/runtime
+- [x] 9.4 Verify post-test database state and restore if needed
+- [x] 9.5 Create report `specs/create-interview/reports/YYYY-MM-DD-step-9-unit-test-and-db-verification.md`
+- [x] 9.6 Mark step complete only after tests pass and the report exists
+
+## 10. Backend: Manual Endpoint Testing with curl (MANDATORY - AGENT MUST EXECUTE)
+
+- [x] 10.1 Ensure the backend server is running and DB connection is active
+- [x] 10.2 Test POST success (full payload) → 201, verify created interview, then delete the created record to restore DB
+- [x] 10.3 Test POST success (minimal payload, result defaults to Pending) → 201, then restore DB
+- [x] 10.4 Test 400 - invalid candidateId format
+- [x] 10.5 Test 400 - missing required field / unexpected field / invalid score / notes too long / invalid result
+- [x] 10.6 Test 404 - candidate not found; application not found / not owned by candidate; step not found; employee not found
+- [x] 10.7 Test 400 - step not in position's flow; employee not active
+- [x] 10.8 Document all curl commands and responses in `specs/create-interview/reports/` (e.g., `CURL_TESTING.md`)
+- [x] 10.9 Verify database state matches pre-test state after cleanup
+
+## 11. Frontend: Service Method
+
+- [x] 11.1 Add `createInterview(candidateId, interviewData)` to `frontend/src/services/interviewService.js`
+- [x] 11.2 Use axios `POST` to `/candidates/${candidateId}/interviews`
+- [x] 11.3 Reuse the same error-extraction pattern as `updateInterview`
+- [x] 11.4 Return the created interview object
+
+## 12. Frontend: CandidateDetails Component Enhancement
+
+- [x] 12.1 Add an "Add interview" action per application section (label from `interviews.addInterview`)
+- [x] 12.2 Add state for the create modal (`creatingForApplication`, `createInterviewData`, `createLoading`, `createError`)
+- [x] 12.3 On click, open the create modal with the application context pre-set
+- [x] 12.4 Build the create modal (React Bootstrap) titled `interviews.createTitle`, reusing edit-form controls:
+  - [x] 12.4.1 Application context (pre-selected for the launching application)
+  - [x] 12.4.2 Interview Date & Time (`datetime-local` input)
+  - [x] 12.4.3 Interview Step (dropdown scoped to the application's position interview flow)
+  - [x] 12.4.4 Employee (dropdown of active employees)
+  - [x] 12.4.5 Result (dropdown: Pending/Passed/Failed; default Pending)
+  - [x] 12.4.6 Score (star rating 0-5)
+  - [x] 12.4.7 Notes (textarea, max 1000 characters)
+- [x] 12.5 Implement submit: validate, convert `datetime-local` → ISO, call `createInterview()`, show loading/disabled state
+- [x] 12.6 On success: close modal, append the new interview to that application's list, show `interviews.createSuccess`
+- [x] 12.7 On validation error: keep modal open with inline errors
+- [x] 12.8 On network/server error: show `interviews.failedToCreate`
+- [x] 12.9 Implement Cancel: close modal without API call, reset form state and errors
+- [x] 12.10 Ensure modal accessibility (keyboard navigation, focus management, aria-labels)
+
+## 13. Frontend: i18n Keys
+
+- [x] 13.1 Add `interviews.createTitle`, `interviews.addInterview`, `interviews.createSuccess`, `interviews.failedToCreate` to `frontend/src/i18n/locales/en.json`
+- [x] 13.2 Add the same keys (Spanish) to `frontend/src/i18n/locales/es.json`
+- [x] 13.3 Reuse existing field-label keys (application, selectApplication, dateTime, step, employee, result, score, notes, saving, save)
+- [x] 13.4 Verify no hardcoded UI strings remain in the create modal
+
+## 14. Frontend: Component Testing
+
+- [x] 14.1 Test "Add interview" action appears per application
+- [x] 14.2 Test clicking the action opens the create modal with application context and empty fields
+- [x] 14.3 Test form validation (required fields, score range, notes length)
+- [x] 14.4 Test successful create appends the interview and shows the success message
+- [x] 14.5 Test Cancel closes the modal without an API call
+- [x] 14.6 Test error handling and display
+
+## 15. Frontend: E2E Testing with Playwright MCP (MANDATORY - AGENT MUST EXECUTE)
+
+- [x] 15.1 Ensure frontend and backend servers are running and DB is in a known state
+- [x] 15.2 Navigate to a candidate's details and open the "Add interview" modal
+- [x] 15.3 Fill the form and submit; verify 201, modal close, new interview in the list, and success message
+- [x] 15.4 Test validation errors keep the modal open
+- [x] 15.5 Test cancel closes the modal without creating
+- [x] 15.6 Restore database state (delete the created interview) and document outcomes in `specs/create-interview/reports/`
+
+## 16. Update Technical Documentation (MANDATORY)
+
+- [x] 16.1 Add `post:` for `/candidates/{candidateId}/interviews` to `docs/api-spec.yml` (responses 201/400/404/500)
+- [x] 16.2 Add `CreateInterviewRequest` schema (`additionalProperties: false`; required: applicationId, interviewStepId, employeeId, interviewDate; optional: result, score, notes)
+- [x] 16.3 Reuse `InterviewResponse` for the 201 response body
+- [x] 16.4 Document path parameter `candidateId` and example request/response
+- [x] 16.5 Confirm `docs/data-model.md` needs no change (Interview already documented); note if otherwise
+- [x] 16.6 Mirror API changes in `openspec/specs/api-spec.yml` if applicable (no `openspec/specs/api-spec.yml` file exists; not applicable)
+
+## 17. Final Verification
+
+- [x] 17.1 Run full backend test suite - all green; verify coverage threshold for new code ✅ (248 tests pass, 4 pre-existing suite failures unrelated to this feature)
+- [x] 17.2 Run frontend build/tests - no ESLint/TypeScript errors ✅ (build succeeds; pre-existing PositionDetails.js unused-var warning not introduced by this feature; 26 frontend tests pass, 1 pre-existing suite failure)
+- [x] 17.3 Manual end-to-end testing - complete create workflow ✅ (Playwright MCP E2E, Test 1 PASS)
+- [x] 17.4 Manual testing - error scenarios (400/404/500) ✅ (curl tests in section 10; validation errors via E2E Test 3)
+- [x] 17.5 Verify acceptance criteria from SCRUM-86 are met:
+  - [x] 17.5.1 `POST /candidates/{candidateId}/interviews` implemented and returns 201 on valid create ✅
+  - [x] 17.5.2 Required-field, value, and business-rule validation enforced with correct status codes ✅
+  - [x] 17.5.3 FK ownership enforced (application↔candidate, step↔flow, active employee) ✅
+  - [x] 17.5.4 Error shape `{ message, error }` consistent with edit/delete ✅
+  - [x] 17.5.5 Frontend "Add interview" action + create modal works, fully i18n'd (en/es) ✅
+  - [x] 17.5.6 No hardcoded UI strings; backend fully typed; DDD layering respected ✅
+  - [x] 17.5.7 API documentation updated ✅

--- a/openspec/specs/create-interview/spec.md
+++ b/openspec/specs/create-interview/spec.md
@@ -1,0 +1,196 @@
+# Spec: Create Interview
+
+## Purpose
+
+Defines the requirements for creating a new interview record for a candidate's application, covering the backend API endpoint, input validation, business-rule enforcement, and the frontend modal UI.
+
+---
+
+## Requirements
+
+### Requirement: Backend API supports interview creation
+The system SHALL provide a `POST` endpoint at `/candidates/{candidateId}/interviews` that accepts interview data, creates a new interview for one of the candidate's applications, and returns the created interview with HTTP `201`. The endpoint SHALL validate the request body, enforce foreign-key ownership and business rules, and return the error shape `{ message, error }` with the appropriate status code on failure.
+
+#### Scenario: Successful interview creation
+- **WHEN** a valid `POST` request is sent to `/candidates/{candidateId}/interviews` with `applicationId`, `interviewStepId`, `employeeId`, `interviewDate`, and optional `result`, `score`, `notes`
+- **THEN** the system SHALL insert a new interview record associated with the given application
+- **AND** the system SHALL return HTTP `201` with the created interview object (`id, applicationId, interviewStepId, employeeId, interviewDate, result, score, notes`)
+
+#### Scenario: Creation with minimal required fields
+- **WHEN** a valid `POST` request contains only the required fields (`applicationId`, `interviewStepId`, `employeeId`, `interviewDate`) and omits `result`
+- **THEN** the system SHALL create the interview with `result` defaulting to `Pending`
+- **AND** the system SHALL return HTTP `201` with the created interview
+
+#### Scenario: Invalid candidate ID format
+- **WHEN** a `POST` request is sent with a non-numeric `candidateId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate an invalid candidate ID format
+
+#### Scenario: Candidate not found
+- **WHEN** a `POST` request targets a `candidateId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the candidate was not found
+
+#### Scenario: Application not found
+- **WHEN** a `POST` request contains an `applicationId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the application was not found
+
+#### Scenario: Application does not belong to candidate
+- **WHEN** a `POST` request contains an `applicationId` that exists but whose `candidateId` does not equal the path `candidateId`
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the application does not belong to the specified candidate
+
+#### Scenario: Unexpected field rejected
+- **WHEN** a `POST` request body contains a field that is not part of the allowed create payload
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that an unexpected field was provided
+- **AND** no interview record SHALL be created
+
+---
+
+### Requirement: Interview creation required-field validation
+The system SHALL require `applicationId`, `interviewStepId`, `employeeId`, and `interviewDate` on creation. Each missing required field SHALL result in HTTP `400` before any database write.
+
+#### Scenario: Missing applicationId
+- **WHEN** a `POST` request omits `applicationId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `applicationId` is required
+
+#### Scenario: Missing interviewStepId
+- **WHEN** a `POST` request omits `interviewStepId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `interviewStepId` is required
+
+#### Scenario: Missing employeeId
+- **WHEN** a `POST` request omits `employeeId`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `employeeId` is required
+
+#### Scenario: Missing interviewDate
+- **WHEN** a `POST` request omits `interviewDate`
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate that `interviewDate` is required
+
+#### Scenario: Non-integer foreign-key field
+- **WHEN** a `POST` request contains `applicationId`, `interviewStepId`, or `employeeId` that is not a positive integer
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the field must be a positive integer
+
+---
+
+### Requirement: Interview creation field-value validation
+The system SHALL validate field values as follows: `interviewDate` must be a valid ISO 8601 date-time; `score` must be an integer between 0 and 5 inclusive or `null`; `notes` must be a string of at most 1000 characters or `null`; `result` must be one of `Pending`, `Passed`, `Failed` (or `null`, defaulting to `Pending` when omitted).
+
+#### Scenario: Interview date validation - valid ISO 8601
+- **WHEN** a `POST` request contains an `interviewDate` in valid ISO 8601 format (e.g., `2026-06-20T10:00:00Z`)
+- **THEN** the system SHALL accept the date and proceed with creation
+
+#### Scenario: Interview date validation - invalid format
+- **WHEN** a `POST` request contains an `interviewDate` that is not valid ISO 8601 or cannot be parsed
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the date is invalid
+
+#### Scenario: Score validation - valid range
+- **WHEN** a `POST` request contains a `score` that is an integer between 0 and 5 inclusive
+- **THEN** the system SHALL accept the score and proceed with creation
+
+#### Scenario: Score validation - out of range
+- **WHEN** a `POST` request contains a `score` less than 0 or greater than 5
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the score must be between 0 and 5
+
+#### Scenario: Score validation - null allowed
+- **WHEN** a `POST` request contains a `score` of `null`
+- **THEN** the system SHALL accept the null value and create the interview with `score` set to null
+
+#### Scenario: Notes validation - within length limit
+- **WHEN** a `POST` request contains `notes` of 1000 characters or fewer
+- **THEN** the system SHALL accept the notes and proceed with creation
+
+#### Scenario: Notes validation - exceeds length limit
+- **WHEN** a `POST` request contains `notes` exceeding 1000 characters
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate notes must not exceed 1000 characters
+
+#### Scenario: Result validation - valid value
+- **WHEN** a `POST` request contains a `result` of `Pending`, `Passed`, or `Failed`
+- **THEN** the system SHALL accept the result and proceed with creation
+
+#### Scenario: Result validation - invalid value
+- **WHEN** a `POST` request contains a `result` that is not one of the allowed values
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the result must be one of `Pending`, `Passed`, `Failed`
+
+#### Scenario: Result validation - default when omitted
+- **WHEN** a `POST` request omits `result`
+- **THEN** the system SHALL create the interview with `result` set to `Pending`
+
+---
+
+### Requirement: Interview creation business-rule validation
+The system SHALL enforce that the interview step exists and belongs to the application's position's interview flow, and that the employee exists and is active, before creating the interview.
+
+#### Scenario: Interview step not found
+- **WHEN** a `POST` request contains an `interviewStepId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the interview step was not found
+
+#### Scenario: Interview step not in position's flow
+- **WHEN** a `POST` request contains an `interviewStepId` that exists but does not belong to the application's position's interview flow
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the interview step does not belong to the position's interview flow
+
+#### Scenario: Employee not found
+- **WHEN** a `POST` request contains an `employeeId` that does not exist
+- **THEN** the system SHALL return HTTP `404`
+- **AND** the response SHALL indicate the employee was not found
+
+#### Scenario: Employee not active
+- **WHEN** a `POST` request contains an `employeeId` that exists but is not active (`isActive = false`)
+- **THEN** the system SHALL return HTTP `400`
+- **AND** the response SHALL indicate the employee is not active
+
+#### Scenario: Internal error
+- **WHEN** an unexpected error occurs while persisting the interview
+- **THEN** the system SHALL return HTTP `500`
+- **AND** the response SHALL not leak internal error details
+
+---
+
+### Requirement: Frontend supports interview creation
+The frontend SHALL provide an "Add interview" action per application section in the Candidate Details pane that opens a modal allowing the recruiter to create a new interview for that application, fully internationalized with no hardcoded UI strings.
+
+#### Scenario: Add interview action appears per application
+- **WHEN** a candidate's details are displayed with one or more applications
+- **THEN** an "Add interview" action SHALL be visible for each application section
+- **AND** the action SHALL be clickable
+
+#### Scenario: Clicking Add interview opens the create modal
+- **WHEN** a recruiter clicks "Add interview" for an application
+- **THEN** a modal titled by the `interviews.createTitle` key SHALL open
+- **AND** the form SHALL include application context, interview date & time (`datetime-local`), interview step (scoped to the application's interview flow), employee, result, score (star rating), and notes
+
+#### Scenario: Successful creation
+- **WHEN** a recruiter fills valid values and submits the create form
+- **THEN** the frontend SHALL convert the `datetime-local` value to ISO 8601 and call the create API
+- **AND** on success the modal SHALL close, the new interview SHALL appear in that application's interview list, and a success message (`interviews.createSuccess`) SHALL be displayed
+
+#### Scenario: Cancel creation
+- **WHEN** a recruiter clicks Cancel in the create modal
+- **THEN** the modal SHALL close without calling the API
+- **AND** the interview list SHALL remain unchanged
+
+#### Scenario: Validation errors displayed in modal
+- **WHEN** a recruiter submits invalid data (e.g., score out of range, notes too long, missing required field)
+- **THEN** validation errors SHALL be displayed inline
+- **AND** the modal SHALL remain open for correction
+
+#### Scenario: Server or network error handling
+- **WHEN** the create API call fails
+- **THEN** an error message (`interviews.failedToCreate`) SHALL be displayed
+- **AND** the interview list SHALL remain unchanged
+
+#### Scenario: Loading state during creation
+- **WHEN** a recruiter submits the create form
+- **THEN** the submit button SHALL show a loading/disabled state during the API call


### PR DESCRIPTION
## Summary

- Add `POST /candidates/{candidateId}/interviews` endpoint with validation, service-layer business rules, and integration tests
- Add create-interview form to Candidate Details (frontend) with i18n support (en/es)
- Update API spec and archive OpenSpec change with synced `create-interview` main spec

## Test plan

- [ ] Backend unit tests pass (`validator`, `interviewService`, `interviewController`)
- [ ] Route integration test passes for create interview
- [ ] Frontend component test passes for create interview flow
- [ ] Manual: open Candidate Details, create an interview against an application, verify it appears in the list


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interview creation capability for candidates. Users can now create interviews for each application via a new "Add Interview" action with a form modal.
  * Includes comprehensive field validation, inline error messaging, and success confirmation.
  * Full internationalization support for English and Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->